### PR TITLE
introduction of  "private" facts

### DIFF
--- a/abilities/collection/5d199f56-698a-41ff-8ae9-bb7b8536adcc.yml
+++ b/abilities/collection/5d199f56-698a-41ff-8ae9-bb7b8536adcc.yml
@@ -1,0 +1,19 @@
+---
+
+- id: 5d199f56-698a-41ff-8ae9-bb7b8536adcc
+  name: Steal sensitive file (using private facts)
+  description: Grab contents of every sensitive file
+  tactic: collection
+  technique:
+    attack_id: T1005
+    name: Data from Local System
+  executors:
+    darwin:
+      command: |
+        cat #{host.file.sensitive.private}
+    linux:
+      command: |
+        cat #{host.file.sensitive.private}
+    windows:
+      command: |
+        Get-Content #{host.file.sensitive.private}

--- a/abilities/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81c.yml
+++ b/abilities/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81c.yml
@@ -1,0 +1,31 @@
+---
+
+- id: 90c2efaa-8205-480d-8bb6-61d90dbaf81c
+  name: Find sensitive files (using private facts)
+  description: Locate files deemed sensitive
+  tactic: collection
+  technique:
+    attack_id: T1005
+    name: Data from Local System
+  executors:
+    darwin:
+      command: |
+        find /Users -name '*.#{file.sensitive.extension}' -type f -not -path '*/\.*' -size -500k 2>/dev/null | head -5
+      parser:
+        name: line
+        property: host.file.sensitive.private
+        script: ''
+    windows:
+      command: |
+        Get-ChildItem C:\Users -Recurse -Include *.#{file.sensitive.extension} | foreach {$_.FullName} | Select-Object -first 5
+      parser:
+        name: line
+        property: host.file.sensitive.private
+        script: ''
+    linux:
+      command: |
+        find / -name '*.#{file.sensitive.extension}' -type f -not -path '*/\.*' -size -500k 2>/dev/null | head -5
+      parser:
+        name: line
+        property: host.file.sensitive.private
+        script: ''

--- a/adversaries.yml
+++ b/adversaries.yml
@@ -23,7 +23,15 @@
       - 90c2efaa-8205-480d-8bb6-61d90dbaf81b
     2:
       - 5d199f56-698a-41ff-8ae9-bb7b8536adcb
-
+      
+- name: File Hunter 2 (using private facts)
+  description: Locate and steal sensitive files
+  phases:
+    1:
+      - 90c2efaa-8205-480d-8bb6-61d90dbaf81c
+    2:
+      - 5d199f56-698a-41ff-8ae9-bb7b8536adcc
+      
 - name: Worm
   description: Move laterally any way possible
   phases:


### PR DESCRIPTION
I introduced a new version of the "File Hunter" adversary who uses private facts instead of normal facts.
By performing two operations (first with the adversary profile "File Hunter" and after "File Hunter 2 (using private facts)" ) with a group of 2 or more agents it is possible to see the usefulness of introducing private facts.