### PR TITLE
introduction of 'private' facts

### DIFF
--- a/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
+++ b/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
@@ -10,12 +10,12 @@
   executors:
     darwin:
       command: |
-        cp "#{host.file.sensitive}" #{files}/staged
+        cp "#{host.file.sensitive.private}" #{files}/staged
     linux:
       command: |
-        cp "#{host.file.sensitive}" #{files}/staged
+        cp "#{host.file.sensitive.private}" #{files}/staged
     windows:
       command: |
-        Copy-Item -Path "#{host.file.sensitive}" -Destination #{files}\staged
+        Copy-Item -Path "#{host.file.sensitive.private}" -Destination #{files}\staged
 
   # see 6469befa-748a-4b9c-a96d-f191fde47d89 for creation of directory 'staged'

--- a/data/abilities/collection/5d199f56-698a-41ff-8ae9-bb7b8536adcb.yml
+++ b/data/abilities/collection/5d199f56-698a-41ff-8ae9-bb7b8536adcb.yml
@@ -10,10 +10,10 @@
   executors:
     darwin:
       command: |
-        cat #{host.file.sensitive}
+        cat #{host.file.sensitive.private}
     linux:
       command: |
-        cat #{host.file.sensitive}
+        cat #{host.file.sensitive.private}
     windows:
       command: |
-        Get-Content #{host.file.sensitive}
+        Get-Content #{host.file.sensitive.private}

--- a/data/abilities/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
+++ b/data/abilities/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
@@ -13,19 +13,19 @@
         find /Users -name '*.#{file.sensitive.extension}' -type f -not -path '*/\.*' -size -500k 2>/dev/null | head -5
       parser:
         name: line
-        property: host.file.sensitive
+        property: host.file.sensitive.private
         script: ''
     windows:
       command: |
         Get-ChildItem C:\Users -Recurse -Include *.#{file.sensitive.extension} | foreach {$_.FullName} | Select-Object -first 5
       parser:
         name: line
-        property: host.file.sensitive
+        property: host.file.sensitive.private
         script: ''
     linux:
       command: |
         find / -name '*.#{file.sensitive.extension}' -type f -not -path '*/\.*' -size -500k 2>/dev/null | head -5
       parser:
         name: line
-        property: host.file.sensitive
+        property: host.file.sensitive.private
         script: ''


### PR DESCRIPTION
I replaced '#{host.file.sensitive}' with '#{host.file.sensitive.private}' in any abilities which are using it to introduce private facts.
Now the behavior of the adversry "File Hunter" is more correct in the operations performed on more agents.

The concept of private facts can obviously improve other adversaries profiles besides the aforementioned "File Hunter".
