### PR TITLE
add empty params object for sequential planner

### DIFF
--- a/app/sequential.py
+++ b/app/sequential.py
@@ -1,8 +1,8 @@
 class LogicalPlanner:
 
-    def __init__(self, data_svc, planning_svc):
-        self.data_svc = data_svc
-        self.planning_svc = planning_svc
+    def __init__(self, services, **params):
+        self.data_svc = services.get('data_svc')
+        self.planning_svc = services.get('planning_svc')
 
     async def execute(self, operation, phase):
         for member in operation['host_group']:

--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -3,3 +3,4 @@
 id: 788107d5-dc1e-4204-9269-38df0186d3e7
 name: sequential
 module: plugins.stockpile.app.sequential
+params: {}


### PR DESCRIPTION
planner yaml 'schema' slightly changing to allow passing in planner options 

See https://github.com/mitre/caldera/pull/360/files 