### PR TITLE
Minor tweaks to prevent caldera from picking up machine accounts

### DIFF
--- a/parsers/mimikatz.py
+++ b/parsers/mimikatz.py
@@ -5,11 +5,13 @@ def mimikatz(blob, log):
     list_lines = blob.split('\n')
     for i, line in enumerate(list_lines):
         if 'Username' in line and '(null)' not in line:
-            username_fact = dict(fact='host.user.name', value=line.split(':')[1].strip(), set_id=set_id)
-            if 'Password' in list_lines[i + 2] and '(null)' not in list_lines[i + 2]:
-                password_fact = dict(fact='host.user.password', value=list_lines[i + 2].split(':')[1].strip(),
-                                     set_id=set_id)
-                matched_facts.append(password_fact)
-                matched_facts.append(username_fact)
-            set_id += 1
+            value = line.split(':')[1].strip()
+            if value[-1] is not '$':
+                username_fact = dict(fact='host.user.name', value=value, set_id=set_id)
+                if 'Password' in list_lines[i + 2] and '(null)' not in list_lines[i + 2]:
+                    password_fact = dict(fact='host.user.password', value=list_lines[i + 2].split(':')[1].strip(),
+                                         set_id=set_id)
+                    matched_facts.append(password_fact)
+                    matched_facts.append(username_fact)
+                    set_id += 1
     return matched_facts


### PR DESCRIPTION
At the moment, Caldera's mimikatz parsing lacks the ability to separate out machine accounts from valid user accounts, resulting in the ingest of unreasonable username and password combinations. This patch excludes machine accounts from the scope of the parsing space.