### PR TITLE
Add a 1s sleep after compressing file before listing path on windows.

### DIFF
--- a/data/abilities/exfiltration/300157e5-f4ad-4569-b533-9d1fa0e74d74.yml
+++ b/data/abilities/exfiltration/300157e5-f4ad-4569-b533-9d1fa0e74d74.yml
@@ -30,7 +30,7 @@
       psh,pwsh:
         command: |
           Compress-Archive -Path #{host.dir.staged} -DestinationPath #{host.dir.staged}.zip -Force;
-          ls #{host.dir.staged}.zip | foreach {$_.FullName} | select
+          sleep 1; ls #{host.dir.staged}.zip | foreach {$_.FullName} | select
         cleanup: |
           rm #{host.dir.staged}.zip
         parsers:


### PR DESCRIPTION
Changes:
* Add a 1s sleep to this ability after compression and before finding the directory

 It seems to fail intermittently when the contents of the staged directory aren't large -- maybe some kind of race condition with file creation / listing in Windows?  I only observed the problem when running via caldera, executing similar command-lines from an interactive powershell prompt didn't throw the same errors.  Unsure as to the root cause,  but this seems to make this ability more reliable. 