### PR TITLE
some access denied does not prevent all file enumeration facts

### DIFF
--- a/data/abilities/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
+++ b/data/abilities/collection/90c2efaa-8205-480d-8bb6-61d90dbaf81b.yml
@@ -20,7 +20,8 @@
     windows:
       psh,pwsh:
         command: |
-          Get-ChildItem C:\Users -Recurse -Include *.#{file.sensitive.extension} | foreach {$_.FullName} | Select-Object -first 5
+          Get-ChildItem C:\Users -Recurse -Include *.#{file.sensitive.extension} -ErrorAction 'SilentlyContinue' | foreach {$_.FullName} | Select-Object -first 5;
+          exit 0;
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.file.sensitive


### PR DESCRIPTION
Changes: 
* Sensitive file enumeration on windows will continue when access denieds occur
* quick fix to make this ability always return success -- previously if sandcat couldn't read any directory, then caldera would not generate facts 

