### PR TITLE
VIRTS-743a: Add description to sequential planner for future dynamic rendering

### DIFF
--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -3,11 +3,12 @@
 id: 788107d5-dc1e-4204-9269-38df0186d3e7
 name: sequential
 description: |
-  CALDERA ships with a default planner, sequential. During each phase of the operation,
-  the sequential planner loops through all agents (which are part of the operation's group)
-  and sends each of them a list of all ability commands the planner thinks it can complete.
-  This decision is based on the agent matching the operating system (execution platform) of
-  the ability and the ability command having no unsatisfied variables. It then waits for each
-  agent to complete their list of commands before moving on to the next phase.
+  CALDERA ships with a default planner, sequential. During each phase of the operation, the sequential planner loops
+  through all agents (which are part of the operation's group) and sends each of them a list of all ability commands
+  the planner thinks it can complete. This decision is based on the agent matching the operating system (execution
+  platform) of the ability and the ability command having no unsatisfied variables. It then waits for each agent to
+  complete their list of commands before moving on to the next phase. In phaseless operations, all applicable commands
+  are executed in a single phase which will then run to completion and finish the operation.
+
 module: plugins.stockpile.app.sequential
 params: {}

--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -2,5 +2,12 @@
 
 id: 788107d5-dc1e-4204-9269-38df0186d3e7
 name: sequential
+description: |
+  CALDERA ships with a default planner, sequential. During each phase of the operation,
+  the sequential planner loops through all agents (which are part of the operation's group)
+  and sends each of them a list of all ability commands the planner thinks it can complete.
+  This decision is based on the agent matching the operating system (execution platform) of
+  the ability and the ability command having no unsatisfied variables. It then waits for each
+  agent to complete their list of commands before moving on to the next phase.
 module: plugins.stockpile.app.sequential
 params: {}


### PR DESCRIPTION
Adds a description key to the sequential planner YAML in preparation for future VIRTS-743 additions that implement dynamic planner description rendering.