### PR TITLE
Remove references to platform in sequential planner

### DIFF
--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -3,12 +3,11 @@
 id: 788107d5-dc1e-4204-9269-38df0186d3e7
 name: sequential
 description: |
-  CALDERA ships with a default planner, sequential. During each phase of the operation, the sequential planner loops
-  through all agents (which are part of the operation's group) and sends each of them a list of all ability commands
-  the planner thinks it can complete. This decision is based on the agent matching the operating system (execution
-  platform) of the ability and the ability command having no unsatisfied variables. It then waits for each agent to
-  complete their list of commands before moving on to the next phase. In phaseless operations, all applicable commands
-  are executed in a single phase which will then run to completion and finish the operation.
-
+  During each phase of the operation, the sequential planner loops through all agents (which are part of the
+  operation's group) and sends each of them a list of all ability commands the planner thinks it can complete. This
+  decision is based on the agent matching the operating system (execution platform) of the ability and the ability 
+  command having no unsatisfied variables. It then waits for each agent to complete their list of commands before
+  moving on to the next phase. In phaseless operations, all applicable commands are executed in a single phase which
+  will then run to completion and finish the operation.
 module: plugins.stockpile.app.sequential
 params: {}


### PR DESCRIPTION
Removes reference to platform and reformatted to line length.