### PR TITLE
Improved IP parser and added filtering to arp -a ability

### DIFF
--- a/app/parsers/ip.py
+++ b/app/parsers/ip.py
@@ -25,7 +25,7 @@ class Parser(BaseParser):
 
     @staticmethod
     def _is_valid_ip(raw_ip):
-        try: 
+        try:
             ip_address(raw_ip)
         except BaseException:
             return False
@@ -59,4 +59,3 @@ class Parser(BaseParser):
             if ip.is_private:
                 return None
         return str(ip)
-

--- a/app/parsers/ip.py
+++ b/app/parsers/ip.py
@@ -31,31 +31,20 @@ class Parser(BaseParser):
             return False
         return True
 
-    @staticmethod
-    def _whitelist_ip(raw_ip, whitelist):
-        try:
-            ip = ip_address(raw_ip)
-        except BaseException:
-            return None
-        if 'multicast' not in whitelist:
-            if ip.is_multicast:
-                return None
-        if 'loopback' not in whitelist:
-            if ip.is_loopback:
-                return None
-        if 'link_local' not in whitelist:
-            if ip.is_link_local:
-                return None
-        if 'reserved' not in whitelist:
-            if ip.is_reserved:
-                return None
-        if 'global' not in whitelist:
-            if ip.is_global:
-                return None
-        if 'unspecified' not in whitelist:
-            if ip.is_unspecified:
-                return None
-        if 'private' not in whitelist:
-            if ip.is_private:
-                return None
-        return str(ip)
+    whitelist_options = {
+        'multicast': 'is_multicast',
+        'loopback': 'is_loopback',
+        'link_local': 'is_link_local',
+        'reserved': 'is_reserved',
+        'global': 'is_global',
+        'unspecified': 'is_unspecified',
+        'private': 'is_private',
+    }
+
+    def _whitelist_ip(self, raw_ip, whitelist):
+        ip = ip_address(raw_ip)
+        for whitelist_option in self.whitelist_options:
+            if whitelist_option not in whitelist:
+                if getattr(ip, self.whitelist_options[whitelist_option]):
+                    return None
+        return raw_ip

--- a/app/parsers/ip.py
+++ b/app/parsers/ip.py
@@ -1,18 +1,62 @@
-from plugins.stockpile.app.parsers.base_parser import BaseParser
 from app.objects.c_relationship import Relationship
+from plugins.stockpile.app.parsers.base_parser import BaseParser
+from ipaddress import IPv4Address as ip_address
+
 
 
 class Parser(BaseParser):
 
     def parse(self, blob):
         relationships = []
-        for match in self.ip(blob):
-            for mp in self.mappers:
-                source = self.set_value(mp.source, match, self.used_facts)
-                target = self.set_value(mp.target, match, self.used_facts)
-                relationships.append(
-                    Relationship(source=(mp.source, source),
-                                 edge=mp.edge,
-                                 target=(mp.target, target))
-                )
+        for ip in self.ip(blob):
+            ip_is_valid = self._is_valid_ip(ip)
+            if ip_is_valid:
+                for mp in self.mappers:
+                    if 'whitelist' in dir(mp):
+                        ip = self._whitelist_ip(ip, mp.whitelist)
+                    if ip:
+                        source = self.set_value(mp.source, ip, self.used_facts)
+                        target = self.set_value(mp.target, ip, self.used_facts)
+                        relationships.append(
+                            Relationship(source=(mp.source, source),
+                                         edge=mp.edge,
+                                         target=(mp.target, target))
+                        )
         return relationships
+
+    @staticmethod
+    def _is_valid_ip(raw_ip):
+        try: 
+            ip = ip_address(raw_ip)
+        except:
+            return False
+        return True
+
+    @staticmethod
+    def _whitelist_ip(raw_ip, whitelist):
+        try:
+            ip = ip_address(raw_ip)
+        except:
+            return None
+        if 'multicast' not in whitelist:
+            if ip.is_multicast:
+                return None
+        if 'loopback' not in whitelist:
+            if ip.is_loopback:
+                return None
+        if 'link_local' not in whitelist:
+            if ip.is_link_local:
+                return None
+        if 'reserved' not in whitelist:
+            if ip.is_reserved:
+                return None
+        if 'global' not in whitelist:
+            if ip.is_global:
+                return None
+        if 'unspecified' not in whitelist:
+            if ip.is_unspecified:
+                return None
+        if 'private' not in whitelist:
+            if ip.is_private:
+                return None
+        return str(ip)

--- a/app/parsers/ip.py
+++ b/app/parsers/ip.py
@@ -5,6 +5,16 @@ from ipaddress import IPv4Address as ip_address
 
 class Parser(BaseParser):
 
+    whitelist_options = {
+        'multicast': 'is_multicast',
+        'loopback': 'is_loopback',
+        'link_local': 'is_link_local',
+        'reserved': 'is_reserved',
+        'global': 'is_global',
+        'unspecified': 'is_unspecified',
+        'private': 'is_private',
+    }
+
     def parse(self, blob):
         relationships = []
         for ip in self.ip(blob):
@@ -30,16 +40,6 @@ class Parser(BaseParser):
         except BaseException:
             return False
         return True
-
-    whitelist_options = {
-        'multicast': 'is_multicast',
-        'loopback': 'is_loopback',
-        'link_local': 'is_link_local',
-        'reserved': 'is_reserved',
-        'global': 'is_global',
-        'unspecified': 'is_unspecified',
-        'private': 'is_private',
-    }
 
     def _whitelist_ip(self, raw_ip, whitelist):
         ip = ip_address(raw_ip)

--- a/app/parsers/ip.py
+++ b/app/parsers/ip.py
@@ -3,7 +3,6 @@ from plugins.stockpile.app.parsers.base_parser import BaseParser
 from ipaddress import IPv4Address as ip_address
 
 
-
 class Parser(BaseParser):
 
     def parse(self, blob):
@@ -27,8 +26,8 @@ class Parser(BaseParser):
     @staticmethod
     def _is_valid_ip(raw_ip):
         try: 
-            ip = ip_address(raw_ip)
-        except:
+            ip_address(raw_ip)
+        except BaseException:
             return False
         return True
 
@@ -36,7 +35,7 @@ class Parser(BaseParser):
     def _whitelist_ip(raw_ip, whitelist):
         try:
             ip = ip_address(raw_ip)
-        except:
+        except BaseException:
             return None
         if 'multicast' not in whitelist:
             if ip.is_multicast:
@@ -60,3 +59,4 @@ class Parser(BaseParser):
             if ip.is_private:
                 return None
         return str(ip)
+

--- a/data/abilities/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
+++ b/data/abilities/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
@@ -14,20 +14,28 @@
         parsers:
           plugins.stockpile.app.parsers.ip:
            - source: remote.host.ip
+             whitelist:
+              - private
     linux:
       sh:
         command: arp -a
         parsers:
           plugins.stockpile.app.parsers.ip:
            - source: remote.host.ip
+             whitelist:
+              - private
     windows:
       psh:
         command: arp -a
         parsers:
           plugins.stockpile.app.parsers.ip:
            - source: remote.host.ip
+             whitelist:
+              - private
       cmd:
         command: arp -a
         parsers:
           plugins.stockpile.app.parsers.ip:
            - source: remote.host.ip
+             whitelist:
+              - private


### PR DESCRIPTION
Changed IP parser to allow for whitelisting of IP address ranges based on their highest level allocation, ie: Global, Private, Multicast, Loopback, etc. Adding no whitelist options to the ability file will result in the parser simply using the ipaddress library to verify the IP coming in from regex in the base parser. Discovery Ability 853... "Arp -a" has been modified to provide an example of the whitelisting functionality and set up to only accept private IP addresses.