### PR TITLE
Revise ACRN list parser

### DIFF
--- a/app/parsers/acrn.py
+++ b/app/parsers/acrn.py
@@ -21,7 +21,6 @@ class Parser(BaseParser):
     @staticmethod
     def _get_vm_names(blob):
         vm_names = []
-        index = 0
         for line in blob.split('\n'):
             line = line.split('\t\t')
             vm_names.append(line[0])

--- a/app/parsers/acrn.py
+++ b/app/parsers/acrn.py
@@ -23,11 +23,6 @@ class Parser(BaseParser):
         vm_names = []
         index = 0
         for line in blob.split('\n'):
-            if 'VM NAME' in line:
-                index = line.index('VM ID')
-                continue
-            if '=====' in line:
-                continue
-            if len(line) > 0:
-                vm_names.append(line[0:index].strip())
+            line = line.split('\t\t')
+            vm_names.append(line[0])
         return vm_names

--- a/data/abilities/discovery/0093c0e0-68b6-4cab-b0d4-2b40b3c78f71.yml
+++ b/data/abilities/discovery/0093c0e0-68b6-4cab-b0d4-2b40b3c78f71.yml
@@ -11,7 +11,7 @@
     linux:
       sh:
         command: |
-          vm_list
+          acrnctl list
         parsers:
           plugins.stockpile.app.parsers.acrn:
             - source: hypervisor.vm.name


### PR DESCRIPTION
Existing ACRN parser is modeled after UART shell output instead of `acrnctl`. The parser has been revised to parse out VM names from `acrnctl` which is accessible through a command.