### PR TITLE
Minor ability changes

### DIFF
--- a/data/abilities/discovery/3b5db901-2cb8-4df7-8043-c4628a6a5d5a.yml
+++ b/data/abilities/discovery/3b5db901-2cb8-4df7-8043-c4628a6a5d5a.yml
@@ -2,7 +2,7 @@
 
 - id: 3b5db901-2cb8-4df7-8043-c4628a6a5d5a
   name: Find user processes
-  description: Get process info for processes running a user
+  description: Get process info for processes running as a user
   tactic: discovery
   technique:
     attack_id: T1057

--- a/data/abilities/discovery/aaf34d82-aea9-4278-8ec4-789653e4f5d9.yml
+++ b/data/abilities/discovery/aaf34d82-aea9-4278-8ec4-789653e4f5d9.yml
@@ -12,7 +12,7 @@
       psh:
         command: |
           Import-Module .\powerview.ps1 -Force;
-          Get-NetUser | ConvertTo-Json -Depth 1
+          Get-NetUser -AdminCount | ConvertTo-Json -Depth 1
         payload: powerview.ps1
         parsers:
           plugins.stockpile.app.parsers.json:

--- a/data/abilities/discovery/c1cd6388-3ced-48c7-a511-0434c6ba8f48.yml
+++ b/data/abilities/discovery/c1cd6388-3ced-48c7-a511-0434c6ba8f48.yml
@@ -3,10 +3,10 @@
 - id: c1cd6388-3ced-48c7-a511-0434c6ba8f48
   name: Find local users
   description: Get a list of all local users
-  tactic: persistence
+  tactic: discovery
   technique:
-    attack_id: T1078
-    name: Valid Accounts
+    attack_id: T1087
+    name: Account Discovery
   platforms:
     darwin:
       sh:


### PR DESCRIPTION
One ability was put under Valid Accounts when it should have been Account Discovery. The tactic was also changed accordingly.

Another ability claimed to discover admins, but actually listed all accounts. Adjusted ability to only list admins.