### PR TITLE
Adding back file hunting to Thief base adversary

### DIFF
--- a/data/adversaries/packs/1a98b8e6-18ce-4617-8cc5-e65a1a9d490e.yml
+++ b/data/adversaries/packs/1a98b8e6-18ce-4617-8cc5-e65a1a9d490e.yml
@@ -6,6 +6,7 @@ description: An adversary pack to steal sensitive files
 phases:
   1:
     - 6469befa-748a-4b9c-a96d-f191fde47d89 #create staging dir
+    - 90c2efaa-8205-480d-8bb6-61d90dbaf81b #find sensitive files
   2:
     - 4e97e699-93d7-4040-b5a3-2e906a58199e #stage files
   3:


### PR DESCRIPTION
* Thief adversary has the ability to enumerate files before exfiltrating them