### PR TITLE
incorrect file name. change vmtools.log to vmtool.log

### DIFF
--- a/data/abilities/collection/8adf02e8-6e71-4244-886c-98c402857404.yml
+++ b/data/abilities/collection/8adf02e8-6e71-4244-886c-98c402857404.yml
@@ -12,4 +12,4 @@
       psh:
         command: |
             tasklist /m  >> $env:APPDATA\vmtool.log;
-            cat $env:APPDATA\vmtools.log
+            cat $env:APPDATA\vmtool.log


### PR DESCRIPTION
The "tasklist Process Enumeration" runs the command `tasklist /m >> $env:APPDATA\vmtool.log;`
However, the next command cat's the incorrect file to display the output. `cat $env:APPDATA\vmtools.log` should be `cat $env:APPDATA\vmtool.log`