### PR TITLE
ignore_enforment_modules should be a list of strings.

### DIFF
--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -11,5 +11,4 @@ description: |
   will then run to completion and finish the operation.
 module: plugins.stockpile.app.sequential
 params: {}
-ignore_enforcement_modules:
-  - {Insert module name here}
+ignore_enforcement_modules: []


### PR DESCRIPTION
ignore_enforment_modules should be a list of strings.

Yaml was loading the example value that was here before as a list of
dictionaries