### PR TITLE
Add empty 'extensions' for payloads

### DIFF
--- a/data/payloads/70632d81-bb39-40dd-bfba-cfd1f8196eb6.yml
+++ b/data/payloads/70632d81-bb39-40dd-bfba-cfd1f8196eb6.yml
@@ -2,6 +2,7 @@
 
 id: 70632d81-bb39-40dd-bfba-cfd1f8196eb6
 name: Stockpile Payloads
+extensions: {}
 standard_payloads:
   Akagi64.exe:
     description: UACME compiled binary


### PR DESCRIPTION
Fix an error introduced with https://github.com/mitre/caldera/commit/7ede1b094e357e160ccd11401efc44e0acbbdc02