### PR TITLE
Adding powershell command and additional fact parse

### DIFF
--- a/data/abilities/defense-evasion/49470433-30ce-4714-a44b-bea9dbbeca9a.yml
+++ b/data/abilities/defense-evasion/49470433-30ce-4714-a44b-bea9dbbeca9a.yml
@@ -7,6 +7,7 @@
   technique:
     attack_id: T1089
     name: Disabling Security Tools
+  privilege: Elevated
   platforms:
     windows:
       psh:

--- a/data/abilities/discovery/26c8b8b5-7b5b-4de1-a128-7d37fb14f517.yml
+++ b/data/abilities/discovery/26c8b8b5-7b5b-4de1-a128-7d37fb14f517.yml
@@ -9,6 +9,9 @@
     name: Remote System Discovery
   platforms:
     windows:
+      cmd:
+        command: |
+          nltest /dsgetdc:%USERDOMAIN%
       psh:
         command: |
-          nltest /dclist:%USERDOMAIN%
+          nltest /dsgetdc:$env:USERDOMAIN

--- a/data/abilities/discovery/364ea817-bbb9-4083-87dd-94b9dba45f6f.yml
+++ b/data/abilities/discovery/364ea817-bbb9-4083-87dd-94b9dba45f6f.yml
@@ -9,6 +9,6 @@
     name: Account Discovery
   platforms:
     windows:
-      cmd:
+      cmd,psh:
         command: |
           net user #{domain.user.name} /domain

--- a/data/abilities/discovery/b22b3b47-6219-4504-a2e6-ae8263e49fc3.yml
+++ b/data/abilities/discovery/b22b3b47-6219-4504-a2e6-ae8263e49fc3.yml
@@ -8,6 +8,9 @@
     name: Remote System Discovery
   platforms:
     windows:
+      cmd:
+        command: |
+          nltest /dsgetdc:%USERDOMAIN%
       psh:
         command: |
-          nltest /dclist:%USERDOMAIN%
+          nltest /dsgetdc:$env:USERDOMAIN

--- a/data/abilities/discovery/c0da588f-79f0-4263-8998-7496b1a40596.yml
+++ b/data/abilities/discovery/c0da588f-79f0-4263-8998-7496b1a40596.yml
@@ -14,12 +14,14 @@
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.user.name
+            - source: domain.user.name
     linux:
       sh:
         command: whoami
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.user.name
+            - source: domain.user.name
     windows:
       psh:
         command: |
@@ -27,8 +29,10 @@
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.user.name
+            - source: domain.user.name
       cmd:
         command: echo %username%
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.user.name
+            - source: domain.user.name


### PR DESCRIPTION
Added a powershell command version for the `Account Discovery (targeted)` ability, and added `domain.user.name` fact output for the `Identify active user` ability. Also added capability to get domain controller IP addresses in the `Find domain controller` ability