### PR TITLE
Fix ability 'Parse SSH config'

### DIFF
--- a/data/abilities/collection/02de522f-7e0a-4544-8afc-0c195f400f5f.yml
+++ b/data/abilities/collection/02de522f-7e0a-4544-8afc-0c195f400f5f.yml
@@ -18,7 +18,7 @@
     linux:
       sh:
         command: |
-          pip install stormssh && storm list
+          pip install -q stormssh 2> /dev/null && storm list | sed 's/\x1b\[[0-9;]*m//g'
         parsers:
           plugins.stockpile.app.parsers.ssh:
             - source: remote.ssh.cmd


### PR DESCRIPTION
- Hide pip output from storm installation
- Filter out storm output control chars for colors

Deals with the **Parse SSH config** ability (`02de522f-7e0a-4544-8afc-0c195f400f5f`) and its parsing.

1. Pip output is not relevant for a parser for this ability and could/does confuse it, although the parser is not working anyways for this ability (see at the bottom).
2. The `storm list` command contains control chars to show the output with colors:
![storm_output](https://user-images.githubusercontent.com/30846672/81475501-f66fb400-920c-11ea-950f-ec062d472a46.png)
For the parser, this would like this:
```
[[1m^[[37mListing entries:^[[0m
 
    ^[[1m^[[32mHOSTNAME^[[0m -> root@xx.xx.xx.xx:22 ^[[37m
     [custom options] ^[[0midentityfile=/root/.ssh/id_rsa
```
`sed` can be used to filter out those control chars (see changes). I assume this fix would also work on macOS, but I don't have one and cannot test it there.

The `ssh` parser used in this ability could not process the input correctly before filtering out the control chars. An alternative would be to filter them out in the parser.

I also noticed that the `ssh` parser used in this ability does not deal correctly with the `storm list` output anyways, since it will match only match `ssh [...]`, which is not the way `storm list` structures its output. It just catches some hosts that have "ssh" in their name or if `ssh` is used in the `proxycommand` section of the `ssh_config`. I assume it was written for the **Dump history** ability (`422526ec-27e9-429a-995b-c686a29561a4`), where it is also used.

I could contribute a parser I've written for the the **Parse SSH config**, but it needs a bit more testing and I would need to ask some questions regarding facts. I will do this in a different PR if you're interested.
