### PR TITLE
Removing xored filename extension from payload section in ability yaml

### DIFF
--- a/data/abilities/credential-access/7049e3ec-b822-4fdf-a4ac-18190f9b66d1.yml
+++ b/data/abilities/credential-access/7049e3ec-b822-4fdf-a4ac-18190f9b66d1.yml
@@ -24,5 +24,4 @@
             edge: has_hash
             target: domain.user.sha1
         payloads:
-        - invoke-mimi.ps1.xored
-        cleanup: Remove-Item -Force -Path "invoke-mimi.ps1"
+        - invoke-mimi.ps1


### PR DESCRIPTION
Ability works when calling payload as "invoke-mimi.ps1". File is still stored as invoke-mimi.ps1.xored server-side