### PR TITLE
Adding atomic sequential planner

### DIFF
--- a/app/atomic.py
+++ b/app/atomic.py
@@ -5,13 +5,13 @@ class LogicalPlanner:
         self.planning_svc = planning_svc
         self.stopping_conditions = stopping_conditions
         self.stopping_condition_met = False
-        self.state_machine = ['atomic_sequential']
-        self.next_bucket = 'atomic_sequential'   # set first (and only) bucket to execute
+        self.state_machine = ['atomic']
+        self.next_bucket = 'atomic'   # set first (and only) bucket to execute
 
     async def execute(self):
         await self.planning_svc.execute_planner(self)
 
-    async def atomic_sequential(self):
+    async def atomic(self):
         done = False
         while not done:
             links_to_use = []

--- a/app/atomic_sequential.py
+++ b/app/atomic_sequential.py
@@ -1,0 +1,48 @@
+class LogicalPlanner:
+
+    def __init__(self, operation, planning_svc, stopping_conditions=()):
+        self.operation = operation
+        self.planning_svc = planning_svc
+        self.stopping_conditions = stopping_conditions
+        self.stopping_condition_met = False
+        self.state_machine = ['atomic_sequential']
+        self.next_bucket = 'atomic_sequential'   # set first (and only) bucket to execute
+
+    async def execute(self):
+        await self.planning_svc.execute_planner(self)
+
+    async def atomic_sequential(self):
+        done = False
+        while not done:
+            links_to_use = []
+
+            # Get the first available link for each agent (make sure we maintain the order).
+            for agent in self.operation.agents:
+                possible_agent_links = await self._get_links(agent=agent)
+                next_link = await self._get_next_atomic_link(possible_agent_links)
+                if next_link:
+                    links_to_use.append(await self.operation.apply(next_link))
+
+            if links_to_use:
+                # Each agent will run the next available step.
+                await self.operation.wait_for_links_completion(links_to_use)
+            else:
+                # No more links to run.
+                done = True
+        self.next_bucket = None
+
+    async def _get_links(self, agent=None):
+        return await self.planning_svc.get_links(operation=self.operation,
+                                                 agent=agent,
+                                                 stopping_conditions=self.stopping_conditions,
+                                                 planner=self)
+
+    # Given list of links, returns the link that appears first in the adversary's atomic ordering.
+    async def _get_next_atomic_link(self, links):
+        abil_id_to_link = dict()
+        for link in links:
+            abil_id_to_link[link.ability.ability_id] = link
+        candidate_ids = set(abil_id_to_link.keys())
+        for ab_id in self.operation.adversary.atomic_ordering:
+            if ab_id in candidate_ids:
+                return abil_id_to_link[ab_id]

--- a/data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
+++ b/data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
@@ -1,15 +1,15 @@
 ---
 
 id: aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a
-name: atomic sequential
+name: atomic
 description: |
-  During each phase of the operation, the atomic sequential planner iterates through each agent and sends the next
+  During each phase of the operation, the atomic planner iterates through each agent and sends the next
   available ability it thinks that agent can complete. This decision is based on the agent matching the operating
   system (execution platform) of the ability and the ability command having no unsatisfied variables.
   The planner then waits for each agent to complete its command before determining the subsequent abilities.
   The abilities are processed in the order set by each agent's atomic ordering.
   For instance, if agent A has atomic ordering (A1, A2, A3) and agent B has atomic ordering (B1, B2, B3), then
   the planner would send (A1, B1) in the first phase, then (A2, B2), etc.
-module: plugins.stockpile.app.atomic_sequential
+module: plugins.stockpile.app.atomic
 params: {}
 ignore_enforcement_modules: []

--- a/data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
+++ b/data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
@@ -1,0 +1,15 @@
+---
+
+id: aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a
+name: atomic sequential
+description: |
+  During each phase of the operation, the atomic sequential planner iterates through each agent and sends the next
+  available ability it thinks that agent can complete. This decision is based on the agent matching the operating
+  system (execution platform) of the ability and the ability command having no unsatisfied variables.
+  The planner then waits for each agent to complete its command before determining the subsequent abilities.
+  The abilities are processed in the order set by each agent's atomic ordering.
+  For instance, if agent A has atomic ordering (A1, A2, A3) and agent B has atomic ordering (B1, B2, B3), then
+  the planner would send (A1, B1) in the first phase, then (A2, B2), etc.
+module: plugins.stockpile.app.atomic_sequential
+params: {}
+ignore_enforcement_modules: []


### PR DESCRIPTION
During each phase of the operation, the atomic sequential planner iterates through each agent and sends the next available ability it thinks that agent can complete. This decision is based on the agent matching the operating system (execution platform) of the ability and the ability command having no unsatisfied variables. The planner then waits for each agent to complete its command before determining the subsequent abilities. The abilities are processed in the order set by each agent's atomic ordering. For instance, if agent A has atomic ordering (A1, A2, A3) and agent B has atomic ordering (B1, B2, B3), then the planner would send (A1, B1) in the first phase, then (A2, B2), etc.
Essentially combines the sequential planner with atomic ordering.
The downside is that since each step in the operation unlocks only one ability per available agent, the flow can be pretty slow for large operations (especially if you have multiple ability variants due to multiple values for single facts)