### PR TITLE
Renaming sequential planner to batch

### DIFF
--- a/app/batch.py
+++ b/app/batch.py
@@ -5,13 +5,13 @@ class LogicalPlanner:
         self.planning_svc = planning_svc
         self.stopping_conditions = stopping_conditions
         self.stopping_condition_met = False
-        self.state_machine = ['sequential']
-        self.next_bucket = 'sequential'   # set first (and only) bucket to execute
+        self.state_machine = ['batch']
+        self.next_bucket = 'batch'   # set first (and only) bucket to execute
 
     async def execute(self):
         await self.planning_svc.execute_planner(self)
 
-    async def sequential(self):
+    async def batch(self):
         links = await self._get_links()
         while links:
             link_ids = [await self.operation.apply(link) for link in links]

--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -1,14 +1,14 @@
 ---
 
 id: 788107d5-dc1e-4204-9269-38df0186d3e7
-name: sequential
+name: batch
 description: |
-  During each phase of the operation, the sequential planner loops through all agents (which are part of the
+  During each phase of the operation, the batch planner loops through all agents (which are part of the
   operation's group) and sends each of them a list of all ability commands the planner thinks it can complete. This
   decision is based on the agent matching the operating system (execution platform) of the ability and the ability 
   command having no unsatisfied variables. It then waits for each agent to complete their list of commands before
   moving on to the next phase. In phaseless operations, all applicable commands are executed in a single phase which
   will then run to completion and finish the operation.
-module: plugins.stockpile.app.sequential
+module: plugins.stockpile.app.batch
 params: {}
 ignore_enforcement_modules: []

--- a/data/planners/f36c34f5-9439-4417-9640-fe83f4b7b12d.yml
+++ b/data/planners/f36c34f5-9439-4417-9640-fe83f4b7b12d.yml
@@ -3,7 +3,7 @@
 id: f36c34f5-9439-4417-9640-fe83f4b7b12d
 name: buckets
 description: |
-  The buckets planner is a variant of the sequential planner that makes use of the new bucket features within Caldera.
+  The buckets planner is a variant of the batch planner that makes use of the new bucket features within Caldera.
   Each of the abilities within caldera are sorted into buckets based on their corresponding tactics in ATT&CK by
   default, with the option of non-default mappings remaining possible. This planner simply loops through all
   abilities available to the provided adversary, in the order of tactics provided in the ATT&CK matrix, looping if


### PR DESCRIPTION
"Batch" is a more fitting name for the old sequential planner, since it provides bulk links at a time