### PR TITLE
virts-1291

### DIFF
--- a/app/parsers/ipaddr.py
+++ b/app/parsers/ipaddr.py
@@ -8,6 +8,9 @@ from app.utility.base_parser import BaseParser
 
 
 class Parser(BaseParser):
+    exclude = ['0.0.0.0', '127.0.0.1']
+    subnet_exclude = ['.255', '.0', '.1']
+
     def parse(self, blob):
         IPs = []
         for ip in re.findall(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', blob):
@@ -18,15 +21,14 @@ class Parser(BaseParser):
                                             target=Fact(mp.target, '')))
         return IPs
 
-    @staticmethod
-    def _is_valid_ip(raw_ip):
+    def _is_valid_ip(self, raw_ip):
         try:
             # The following hardcoded addresses are not used to bind to an interface.
-            if raw_ip in ['0.0.0.0', '127.0.0.1']:  # nosec
+            if raw_ip in self.exclude:
                 return False
-            if any([True if raw_ip.endswith(x) else None for x in ['.255', '.0', '.1']]):
+            if any([True if raw_ip.endswith(x) else None for x in self.subnet_exclude]):
                 return False
             ip_address(raw_ip)
-        except BaseException:
+        except Exception:
             return False
         return True

--- a/app/parsers/ipaddr.py
+++ b/app/parsers/ipaddr.py
@@ -1,0 +1,26 @@
+import re
+
+from ipaddress import ip_address
+
+from app.objects.secondclass.c_fact import Fact
+from app.objects.secondclass.c_relationship import Relationship
+from app.utility.base_parser import BaseParser
+
+class Parser(BaseParser):
+    def parse(self, blob):
+        IPs = []
+        for ip in re.findall(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', blob):
+            if self._is_valid_ip(ip):
+                IPs.append(Relationship(source=Fact(trait='remote.host.ip', value=ip), edge=''))
+        return IPs
+
+    @staticmethod
+    def _is_valid_ip(raw_ip):
+        try:
+            # The following hardcoded addresses are not used to bind to an interface.
+            if raw_ip in ['0.0.0.0', '127.0.0.1']:  # nosec
+                return False
+            ip_address(raw_ip)
+        except BaseException:
+            return False
+        return True

--- a/app/parsers/ipaddr.py
+++ b/app/parsers/ipaddr.py
@@ -6,6 +6,7 @@ from app.objects.secondclass.c_fact import Fact
 from app.objects.secondclass.c_relationship import Relationship
 from app.utility.base_parser import BaseParser
 
+
 class Parser(BaseParser):
     def parse(self, blob):
         IPs = []

--- a/app/parsers/ipaddr.py
+++ b/app/parsers/ipaddr.py
@@ -11,7 +11,10 @@ class Parser(BaseParser):
         IPs = []
         for ip in re.findall(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', blob):
             if self._is_valid_ip(ip):
-                IPs.append(Relationship(source=Fact(trait='remote.host.ip', value=ip), edge=''))
+                for mp in self.mappers:
+                    IPs.append(Relationship(source=Fact(trait=mp.source, value=ip),
+                                            edge=mp.edge,
+                                            target=Fact(mp.target, '')))
         return IPs
 
     @staticmethod
@@ -19,6 +22,8 @@ class Parser(BaseParser):
         try:
             # The following hardcoded addresses are not used to bind to an interface.
             if raw_ip in ['0.0.0.0', '127.0.0.1']:  # nosec
+                return False
+            if any([True if raw_ip.endswith(x) else None for x in ['.255', '.0', '.1']]):
                 return False
             ip_address(raw_ip)
         except BaseException:

--- a/data/abilities/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
+++ b/data/abilities/discovery/85341c8c-4ecb-4579-8f53-43e3e91d7617.yml
@@ -11,9 +11,18 @@
     darwin:
       sh:
         command: arp -a
+        parsers:
+          plugins.stockpile.app.parsers.ipaddr:
+            - source: remote.host.ip
     linux:
       sh:
         command: arp -a
+        parsers:
+          plugins.stockpile.app.parsers.ipaddr:
+            - source: remote.host.ip
     windows:
       psh,cmd:
         command: arp -a
+        parsers:
+          plugins.stockpile.app.parsers.ipaddr:
+            - source: remote.host.ip


### PR DESCRIPTION
Adds a remote.host.ip parser to arp retrieval so that the addresses can be used by the planner.