### PR TITLE
Specifying elevated priv requirement for defense evasion ability

### DIFF
--- a/data/abilities/defense-evasion/b007f6e8-4a87-4440-8888-29ceab047d9b.yml
+++ b/data/abilities/defense-evasion/b007f6e8-4a87-4440-8888-29ceab047d9b.yml
@@ -7,6 +7,7 @@
   technique:
     attack_id: T1089
     name: Disabling Security Tools
+  privilege: Elevated
   platforms:
     windows:
       psh:


### PR DESCRIPTION
Elevated priv required to turn off windows defender settings