### PR TITLE
Donut improvements

### DIFF
--- a/app/donut.py
+++ b/app/donut.py
@@ -1,23 +1,69 @@
 import donut
 import os
+import base64
 
 
-async def donut_handler(services, args) -> (str, str):
-    _, file_name = await services.get('file_svc').find_file_path(args.get('file'), location='payloads')
-    dir_path, donut_ext = os.path.split(file_name)
-    exe_path = os.path.join(dir_path, '%s.exe' % donut_ext.split('.')[0])
-    os.replace(src=file_name, dst=exe_path)
-    shellcode = donut.create(file=exe_path)
+async def donut_handler(services, args):
+    """Handle donut special payloads
+
+    :param services: CALDERA services
+    :type services: dict
+    :param args: HTTP request arguments
+    :type args: multidict
+    :return: Payload, display name
+    :rtype: string, string
+    """
+    _, donut_path = await services.get('file_svc').find_file_path(args.get('file'), location='payloads')
+    donut_dir, donut_file = os.path.split(donut_path)
+    exe_path = os.path.join(donut_dir, '%s.exe' % donut_file.split('.')[0])
+    os.replace(src=donut_path, dst=exe_path)
+    parameters = await _get_parameters(services.get('data_svc'), args.get('file'))
+    shellcode = donut.create(file=exe_path, params=parameters)
     _write_shellcode_to_file(shellcode, exe_path)
-    os.replace(src=exe_path, dst=file_name)
-    return donut_ext, donut_ext  # payload, display_name
+    os.replace(src=exe_path, dst=donut_path)
+    return donut_file, donut_file  # payload, display_name
 
 """ PRIVATE """
 
 
-def _write_shellcode_to_file(shellcode, file_name):
+def _write_shellcode_to_file(shellcode, file_path):
+    """Write shellcode to file path
+
+    :param shellcode: Shellcode byte string
+    :type shellcode: bytes
+    :param file_path: File path to write to
+    :type file_path: string
+    """
     try:
-        with open(file_name, 'wb') as f:
+        with open(file_path, 'wb') as f:
             f.write(shellcode)
     except Exception as ex:
         print(ex)
+
+
+async def _get_parameters(data_svc, file_name):
+    """Generate command line parameters from latest matching link
+
+    Parameters are everything after the first instance of the payload
+    (donut file name) in the ability command
+
+    :param data_svc: Data service to collect operations
+    :type data_svc: DataService
+    :return: Donut parameters
+    :rtype: string
+    """
+    parameters = ''
+    operations = await data_svc.locate('operations', match=dict(state='running'))
+    potential_links = [chain for operation in operations for chain in operation.chain
+                       if not chain.finish and chain.ability.executor.startswith('donut')
+                       and file_name in chain.ability.payloads]
+    if potential_links:
+        link = sorted(potential_links, key=lambda l: l.decide)[0]
+        operation = [operation for operation in operations if operation.has_link(link.id)][0]
+        if operation.obfuscator == 'plain-text':
+            decoded_command = base64.b64decode(link.command).decode('utf-8')
+            if file_name in decoded_command:
+                parameters = ''.join(decoded_command.split(file_name)[1:])
+            else:
+                parameters = decoded_command
+    return parameters

--- a/app/donut.py
+++ b/app/donut.py
@@ -15,7 +15,7 @@ async def donut_handler(services, args):
     """
     _, donut_path = await services.get('file_svc').find_file_path(args.get('file'), location='payloads')
     donut_dir, donut_file = os.path.split(donut_path)
-    exe_path = os.path.join(donut_dir, '%s.exe' % donut_file.split('.')[0])
+    exe_path = os.path.join(donut_dir, '{}.exe'.format(donut_file))
     os.replace(src=donut_path, dst=exe_path)
     parameters = await _get_parameters(services.get('data_svc'), args.get('file'))
     shellcode = donut.create(file=exe_path, params=parameters)

--- a/app/donut.py
+++ b/app/donut.py
@@ -7,6 +7,9 @@ import shlex
 async def donut_handler(services, args):
     """Handle donut special payloads
 
+    Creates .donut files from the .donut.exe files created by the
+    builder plugin
+
     :param services: CALDERA services
     :type services: dict
     :param args: HTTP request arguments
@@ -14,15 +17,15 @@ async def donut_handler(services, args):
     :return: Payload, display name
     :rtype: string, string
     """
-    _, donut_path = await services.get('file_svc').find_file_path(args.get('file'), location='payloads')
-    donut_dir, donut_file = os.path.split(donut_path)
-    exe_path = os.path.join(donut_dir, '{}.exe'.format(donut_file))
-    os.replace(src=donut_path, dst=exe_path)
+    donut_file = args.get('file')
+    exe_file = '{}.exe'.format(donut_file)
+    _, exe_path = await services.get('file_svc').find_file_path(exe_file, location='payloads')
+    donut_dir, _ = os.path.split(exe_path)
+    donut_path = os.path.join(donut_dir, donut_file)
     parameters = await _get_parameters(services.get('data_svc'), args.get('file'))
     shellcode = donut.create(file=exe_path, params=parameters)
-    _write_shellcode_to_file(shellcode, exe_path)
-    os.replace(src=exe_path, dst=donut_path)
-    return donut_file, donut_file  # payload, display_name
+    _write_shellcode_to_file(shellcode, donut_path)
+
 
 """ PRIVATE """
 

--- a/app/donut.py
+++ b/app/donut.py
@@ -49,6 +49,10 @@ def _write_shellcode_to_file(shellcode, file_path):
 async def _get_parameters(data_svc, file_name):
     """Generate command line parameters from latest matching link
 
+    Links are matched based on the earliest started matching ability.
+
+    This will only work with the plain-text obfuscator.
+
     Parameters are everything after the first instance of the payload
     (donut file name) in the ability command.
 
@@ -74,5 +78,8 @@ async def _get_parameters(data_svc, file_name):
             if file_name in decoded_command:
                 parameters = shlex.split(''.join(decoded_command.split(file_name)[1:]))
             else:
+                print('[!] Donut file name missing from command in ability "{}". Prepend "{}"'.format(link.ability.name,
+                                                                                                      file_name))
+                print('[!] {} may need to be deleted from the remote machine.'.format(file_name))
                 parameters = shlex.split(decoded_command)
     return ','.join(parameters)

--- a/app/donut.py
+++ b/app/donut.py
@@ -22,9 +22,10 @@ async def donut_handler(services, args):
     _, exe_path = await services.get('file_svc').find_file_path(exe_file, location='payloads')
     donut_dir, _ = os.path.split(exe_path)
     donut_path = os.path.join(donut_dir, donut_file)
-    parameters = await _get_parameters(services.get('data_svc'), args.get('file'))
+    parameters = await _get_parameters(services.get('data_svc'), donut_file)
     shellcode = donut.create(file=exe_path, params=parameters)
     _write_shellcode_to_file(shellcode, donut_path)
+    return donut_file, donut_file
 
 
 """ PRIVATE """
@@ -71,8 +72,7 @@ async def _get_parameters(data_svc, file_name):
         if operation.obfuscator == 'plain-text':
             decoded_command = base64.b64decode(link.command).decode('utf-8')
             if file_name in decoded_command:
-                param_string = ''.join(decoded_command.split(file_name)[1:])
+                parameters = shlex.split(''.join(decoded_command.split(file_name)[1:]))
             else:
-                param_string = decoded_command
-            parameters = shlex.split(param_string)
+                parameters = shlex.split(decoded_command)
     return ','.join(parameters)


### PR DESCRIPTION
- Added parameters for donut. Allows facts to be passed to C# code as arguments. For example: `command: .\HelloNameDonut.donut "#{paw}"` would pass the paw to the `Main()` function.
- Rewrote variable names for clarity.
- Builder improvements append .exe during build process. This way, we can generate a new .donut payload each time an ability is run. Previously, the .donut file would be built once (as a normal executable), then it would be overwritten. Any ability using the ability after this would be working with the already-processed .donut file.