### PR TITLE
Mimikatz parser improvements

### DIFF
--- a/app/parsers/katz.py
+++ b/app/parsers/katz.py
@@ -81,7 +81,8 @@ class Parser(BaseParser):
                             for mp in self.mappers:
                                 target_key = self.target_mapping.get(mp.target.split('.')[-1],
                                                                      self.target_mapping['_default'])
-                                if target_key in provider:
+                                if target_key in provider and not (target_key == 'Password'
+                                                                   and provider[target_key] == '(null)'):
                                     relationships.append(
                                         Relationship(source=Fact(mp.source, username),
                                                      edge=mp.edge,
@@ -132,8 +133,7 @@ class Parser(BaseParser):
                 return True, match_group.group(1)  # reset the provider
         return False, provider_name
 
-    @staticmethod
-    def _provider_extend(provider, provider_name, logon_session):
+    def _provider_extend(self, provider, provider_name, logon_session):
         if 'Username' in provider and provider['Username'] != '(null)' and \
-                (('Password' in provider and provider['Password'] != '(null)') or 'NTLM' in provider):
+                any([cred for cred in self.target_mapping.values() if cred in provider]):
             logon_session.providers[provider_name].append(provider)

--- a/app/parsers/katz.py
+++ b/app/parsers/katz.py
@@ -119,7 +119,7 @@ class Parser(BaseParser):
 
     def _process_provider(self, line, provider, provider_name, logon_session):
         if line.startswith('['):
-            self._provider_extend(provider, provider_name, logon_session) # this might indicate the start of a new account
+            self._provider_extend(provider, provider_name, logon_session)  # indicates the start of a new account
             return True, provider_name  # reset the provider
         elif line.startswith('*'):
             m = re.match(r'\s*\* (.*?)\s*: (.*)', line)

--- a/app/parsers/katz.py
+++ b/app/parsers/katz.py
@@ -15,7 +15,7 @@ class MimikatzBlock(object):
         self.logon_server = ''
         self.logon_time = ''
         self.sid = ''
-        self.packages = defaultdict(list)
+        self.providers = defaultdict(list)
 
 
 class Parser(BaseParser):
@@ -23,7 +23,7 @@ class Parser(BaseParser):
     def __init__(self, parser_info):
         self.mappers = parser_info['mappers']
         self.used_facts = parser_info['used_facts']
-        self.parse_mode = ['wdigest', 'credman', 'msv']
+        self.providers = ['wdigest', 'credman', 'msv', 'kerberos', 'ssp']
         self.log = logging.getLogger('parsing_svc')
         self.hash_check = r'([0-9a-fA-F][0-9a-fA-F] ){3}'
         self.target_mapping = {'password': 'Password',
@@ -38,53 +38,55 @@ class Parser(BaseParser):
         Args:
             output: stdout of "mimikatz.exe privilege::debug sekurlsa::logonpasswords exit"
         Returns:
-            A list of MimikatzSection objects
+            A list of Mimikatzsession objects
         """
-        sections = output.split('Authentication Id')  # split sections using "Authentication Id" as separator
+        sessions = output.split('Authentication Id')  # split sessions using "Authentication Id" as separator
         creds = []
-        for section in sections:
-            mk_section = MimikatzBlock()
-            package = {}
-            package_name = ''
+        for session in sessions:
+            logon_session = MimikatzBlock()
+            provider = {}
+            provider_name = ''
             in_header = True
-            pstate = False
-            for line in section.splitlines():
+            provider_state = False
+            for line in session.splitlines():
                 line = line.strip()
                 if in_header:
-                    in_header = self._parse_header(line, mk_section)
+                    in_header = self._parse_header(line, logon_session)
                     if in_header:
                         continue  # avoid excess parsing work
-                pstate, package_name = self._process_package(line, package, package_name, mk_section)
-                if pstate:
-                    pstate = False
-                    package = {}
-            self._package_extend(package, package_name, mk_section)  # save the current ssp if necessary
-            if mk_section.packages:  # save this section
-                creds.append(mk_section)
+                provider_state, provider_name = self._process_provider(line, provider, provider_name, logon_session)
+                if provider_state:
+                    provider_state = False
+                    provider = {}
+            self._provider_extend(provider, provider_name, logon_session)  # save the current ssp if necessary
+            if logon_session.providers:  # save this session
+                creds.append(logon_session)
         return creds
 
     def parse(self, blob):
         relationships = []
         try:
-            parse_data = self.parse_katz(blob)
-            for match in parse_data:
-                if match.logon_server != '(null)' or 'credman' in match.packages:
-                    for pm in self.parse_mode:
-                        if pm in match.packages:
-                            hash_pass = re.match(self.hash_check, match.packages[pm][0].get('Password', ''))
-                            if not hash_pass:
-                                if pm == 'credman':
-                                    split = match.packages[pm][0]['Username'].split('\\')
-                                    if len(split) > 1:
-                                        match.packages[pm][0]['Username'] = split[1]
-                                for mp in self.mappers:
-                                    target_index = self.target_mapping.get(mp.target.split('.')[2], self.target_mapping['_default'])
-                                    if target_index in match.packages[pm][0]:
-                                        relationships.append(
-                                            Relationship(source=Fact(mp.source, match.packages[pm][0]['Username']),
-                                                         edge=mp.edge,
-                                                         target=Fact(mp.target, match.packages[pm][0][target_index]))
-                                        )
+            logon_sessions = self.parse_katz(blob)
+            valid_sessions = [logon_session for logon_session in logon_sessions
+                              if logon_session.logon_server != '(null)' or 'credman' in logon_session.providers]
+            for logon_session in valid_sessions:
+                provider_names = [provider for provider in logon_session.providers if provider in self.providers]
+                for provider_name in provider_names:
+                    for provider in logon_session.providers[provider_name]:
+                        if not re.match(self.hash_check, provider.get('Password', '')):
+                            if provider_name == 'credman':
+                                username = provider['Username'].lower()
+                            else:
+                                username = '{}\\{}'.format(provider['Domain'], provider['Username']).lower()
+                            for mp in self.mappers:
+                                target_key = self.target_mapping.get(mp.target.split('.')[-1],
+                                                                     self.target_mapping['_default'])
+                                if target_key in provider:
+                                    relationships.append(
+                                        Relationship(source=Fact(mp.source, username),
+                                                     edge=mp.edge,
+                                                     target=Fact(mp.target, provider[target_key]))
+                                    )
         except Exception as error:
             self.log.warning('Mimikatz parser encountered an error - {}. Continuing...'.format(error))
         return relationships
@@ -92,46 +94,46 @@ class Parser(BaseParser):
     """    PRIVATE FUNCTION     """
 
     @staticmethod
-    def _parse_header(line, mk_section):
+    def _parse_header(line, logon_session):
         if line.startswith('msv'):
             return False
         session = re.match(r'^\s*Session\s*:\s*([^\r\n]*)', line)
         if session:
-            mk_section.session = session.group(1)
+            logon_session.session = session.group(1)
         username = re.match(r'^\s*User Name\s*:\s*([^\r\n]*)', line)
         if username:
-            mk_section.username = username.group(1)
+            logon_session.username = username.group(1)
         domain = re.match(r'^\s*Domain\s*:\s*([^\r\n]*)', line)
         if domain:
-            mk_section.domain = domain.group(1)
+            logon_session.domain = domain.group(1)
         logon_server = re.match(r'^\s*Logon Server\s*:\s*([^\r\n]*)', line)
         if logon_server:
-            mk_section.logon_server = logon_server.group(1)
+            logon_session.logon_server = logon_server.group(1)
         logon_time = re.match(r'^\s*Logon Time\s*:\s*([^\r\n]*)', line)
         if logon_time:
-            mk_section.logon_time = logon_time.group(1)
+            logon_session.logon_time = logon_time.group(1)
         sid = re.match(r'^\s*SID\s*:\s*([^\r\n]*)', line)
         if sid:
-            mk_section.sid = sid.group(1)
+            logon_session.sid = sid.group(1)
         return True
 
-    def _process_package(self, line, package, package_name, mk_section):
+    def _process_provider(self, line, provider, provider_name, logon_session):
         if line.startswith('['):
-            self._package_extend(package, package_name, mk_section)  # this might indicate the start of a new account
-            return True, package_name  # reset the package
+            self._provider_extend(provider, provider_name, logon_session) # this might indicate the start of a new account
+            return True, provider_name  # reset the provider
         elif line.startswith('*'):
             m = re.match(r'\s*\* (.*?)\s*: (.*)', line)
             if m:
-                package[m.group(1)] = m.group(2)
+                provider[m.group(1)] = m.group(2)
         elif line:
-            match_group = re.match(r'([a-z]+) :', line)  # parse out the new section name
+            match_group = re.match(r'([a-z]+) :', line)  # parse out the new session name
             if match_group:  # this is the start of a new ssp
-                self._package_extend(package, package_name, mk_section)  # save the current ssp if necessary
-                return True, match_group.group(1)  # reset the package
-        return False, package_name
+                self._provider_extend(provider, provider_name, logon_session)  # save the current ssp if necessary
+                return True, match_group.group(1)  # reset the provider
+        return False, provider_name
 
     @staticmethod
-    def _package_extend(package, package_name, mk_section):
-        if 'Username' in package and package['Username'] != '(null)' and \
-                (('Password' in package and package['Password'] != '(null)') or 'NTLM' in package):
-            mk_section.packages[package_name].append(package)
+    def _provider_extend(provider, provider_name, logon_session):
+        if 'Username' in provider and provider['Username'] != '(null)' and \
+                (('Password' in provider and provider['Password'] != '(null)') or 'NTLM' in provider):
+            logon_session.providers[provider_name].append(provider)


### PR DESCRIPTION
* Adds providers: kerberos, ssp
* Grabs all credentials for provider in a given logon session. Previously, only the first instance would be grabbed for, for example, multiple credentials under the ssp provider
* Returns domain\user for username (this change may be up for debate)
* Make "valid" logon sessions check based on `target_mapping` values (instead of static 'NTLM')
* More appropriate variable names