### PR TITLE
Fix technique names with ':' in title

### DIFF
--- a/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
+++ b/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
@@ -6,7 +6,7 @@
   tactic: collection
   technique:
     attack_id: T1074.001
-    name: Data Staged: Local Data Staging
+    name: "Data Staged: Local Data Staging"
   platforms:
     darwin:
       sh:

--- a/data/abilities/collection/6469befa-748a-4b9c-a96d-f191fde47d89.yml
+++ b/data/abilities/collection/6469befa-748a-4b9c-a96d-f191fde47d89.yml
@@ -6,7 +6,7 @@
   tactic: collection
   technique:
     attack_id: T1074.001
-    name: Data Staged: Local Data Staging
+    name: "Data Staged: Local Data Staging"
   platforms:
     darwin:
       sh:

--- a/data/abilities/command-and-control/0ab383be-b819-41bf-91b9-1bd4404d83bf.yml
+++ b/data/abilities/command-and-control/0ab383be-b819-41bf-91b9-1bd4404d83bf.yml
@@ -4,7 +4,7 @@
   tactic: command-and-control
   technique:
     attack_id: T1071.001
-    name: Application Layer Protocol: Web Protocols
+    name: "Application Layer Protocol: Web Protocols"
   platforms:
     darwin:
       sh:


### PR DESCRIPTION
MITRE ATT&CK sub-techniques will include `:` in the form of `primary technique: sub technique`
Since everything is yaml on the backend, the technique name need to be wrapped in quotes to not actively process the semicolon.