### PR TITLE
Add ability: Password Policy for a domain

### DIFF
--- a/data/abilities/discovery/2946edba-54d8-11eb-ae93-0242ac130002.yml
+++ b/data/abilities/discovery/2946edba-54d8-11eb-ae93-0242ac130002.yml
@@ -1,0 +1,14 @@
+---
+
+- id: 2946edba-54d8-11eb-ae93-0242ac130002
+  name: Password Policy for a domain
+  description: Password Policy Discovery for a domain
+  tactic: discovery
+  technique:
+    attack_id: T1201
+    name: Password Policy Discovery for a domain
+  platforms:
+    windows:
+      psh:
+        command: |
+          net accounts /domain


### PR DESCRIPTION
Currently I found only [local password policy discovery ability](https://github.com/mitre/stockpile/blob/master/data/abilities/discovery/e82f39e2-56f8-4f19-8376-b007f9ac5f8a.yml) in stockpile repo, so I decided to add ability for domain password policy discovery because really need it  