### PR TITLE
Added new ability: Check Security Services

### DIFF
--- a/data/abilities/defense-evasion/1258b063-27d6-489b-a677-4807faacf868.yml
+++ b/data/abilities/defense-evasion/1258b063-27d6-489b-a677-4807faacf868.yml
@@ -1,0 +1,89 @@
+---
+
+- id: 1258b063-27d6-489b-a677-4807faacf868
+  name: Check Security Services
+  description: "Check for security services. Security service list is based on the SUNBURST malware observed in a Solarwinds related compromise (https://research.checkpoint.com/2020/sunburst-teardrop-and-the-netsec-new-normal/)."
+  tactic: defense-evasion
+  technique:
+    attack_id: T1497.001
+    name: "Virtualization/Sandbox Evasion: System Checks"
+  platforms:
+    windows:
+      psh,pwsh:
+        command: |
+          $sercurityServices = @(
+              "msmpeng",
+              "windefend",
+              "mssense",
+              "sense",
+              "microsoft.tri.sensor",
+              "microsoft.tri.sensor.updater",
+              "cavp",
+              "cb",
+              "carbonblack",
+              "carbonblackk",
+              "cbcomms",
+              "cbstream",
+              "csfalconservice",
+              "csfalconcontainer",
+              "csagent",
+              "csdevicecontrol",
+              "csfalconservice",
+              "xagt",
+              "xagtnotif",
+              "fe_avk",
+              "fekern",
+              "feelam",
+              "fewscservice",
+              "ekrn",
+              "eguiproxy",
+              "egui",
+              "eamonm",
+              "eelam",
+              "ehdrv",
+              "ekrnepfw",
+              "epfwwfp",
+              "ekbdflt",
+              "epfw",
+              "fsgk32st",
+              "fswebuid",
+              "fsgk32",
+              "fsma32",
+              "fssm32",
+              "fnrb32",
+              "fsaua",
+              "fsorsp",
+              "fsav32",
+              "f-secure gatekeeper handler starter",
+              "f-secure network request broker",
+              "f-secure webui daemon",
+              "fsma",
+              "fsorspclient",
+              "f-secure gatekeeper",
+              "f-secure hips",
+              "fsbts",
+              "fsni",
+              "fsvista",
+              "f-secure filter",
+              "f-secure recognizer",
+              "fses",
+              "fsfw",
+              "fsdfw",
+              "fsms",
+              "fsdevcon"
+          );
+
+          $currentServices = Get-Service | Select-Object -Property Name;
+          foreach ($svc in $currentServices) {
+              foreach ($secSvc in $sercurityServices) {
+                  if ($svc.Name -like $secSvc) {
+                      $svcDetails = Get-Service -name $svc.Name | Select-Object -Property Name, DisplayName, Status;
+                      Write-Host "[!] Security service found:";
+                      Write-Host "    Service Name:`t", $svcDetails.Name;
+                      Write-Host "    Display Name:`t", $svcDetails.DisplayName;
+                      Write-Host "    Status:`t`t", $svcDetails.Status;
+                      Write-Host "";
+                  }
+              }
+          }
+


### PR DESCRIPTION
This pull request adds a new defense evasion ability, Check Security Services, which checks for the presence of over 50 services associated with common personal security products.

This ability is based on functionality observed in the SUNBURST malware, which was observed by Check Point as part of SolarWinds related investigations (https://research.checkpoint.com/2020/sunburst-teardrop-and-the-netsec-new-normal/).

This ability was tested on Windows 10 Enterprise (64-bit) build 1809 and works on Windows PowerShell and PowerShell Core.

Successful ability output will resemble:

```
[!] Security service found:
    Service Name:        Sense
    Display Name:        Windows Defender Advanced Threat Protection Service
    Status:              Stopped

[!] Security service found:
    Service Name:        WinDefend
    Display Name:        Windows Defender Antivirus Service
    Status:              Running
```