### PR TITLE
VIRTS1541: added allow repeatable abilities fields to existing planners

### DIFF
--- a/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
+++ b/data/planners/788107d5-dc1e-4204-9269-38df0186d3e7.yml
@@ -12,3 +12,4 @@ description: |
 module: plugins.stockpile.app.batch
 params: {}
 ignore_enforcement_modules: []
+allow_repeatable_abilities: True

--- a/data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
+++ b/data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
@@ -13,3 +13,4 @@ description: |
 module: plugins.stockpile.app.atomic
 params: {}
 ignore_enforcement_modules: []
+allow_repeatable_abilities: False

--- a/data/planners/f36c34f5-9439-4417-9640-fe83f4b7b12d.yml
+++ b/data/planners/f36c34f5-9439-4417-9640-fe83f4b7b12d.yml
@@ -11,3 +11,4 @@ description: |
 module: plugins.stockpile.app.buckets
 params: {}
 ignore_enforcement_modules: []
+allow_repeatable_abilities: False


### PR DESCRIPTION
related https://github.com/mitre/caldera/pull/2019

While the added field is only really necessary in `batch`, the `allow_repeatable_abilities` property was added to the other two planners for consistency. `allow_repeatable_abilities` will default to false if not provided.