### PR TITLE
fixing base64 jumble obfuscator for window powershell commands

### DIFF
--- a/app/obfuscators/base64_jumble.py
+++ b/app/obfuscators/base64_jumble.py
@@ -28,12 +28,12 @@ class Obfuscation(BaseObfuscator):
         return 'eval "$(echo %s | rev | cut -c%s- | rev | base64 --decode)"' % (link.command, extra_chars)
 
     def psh(self, link, **kwargs):
-        extra_chars = kwargs.get('extra') + 1
+        extra_chars = kwargs.get('extra')
         try:
             recoded = b64encode(self.decode_bytes(link.command).encode('UTF-16LE'))
         except binascii.Error:  # Resolve issue where we can't decode our own mangled command internally
-            recoded = b64encode(self.decode_bytes(link.command[:-(extra_chars-1)]).encode('UTF-16LE'))
-        return 'powershell -Enc %s.Substring(0,%s)' % (recoded.decode('utf-8'), len(link.command)-extra_chars)
+            recoded = b64encode(self.decode_bytes(link.command[:-extra_chars]).encode('UTF-16LE'))
+        return 'powershell -Enc %s' % recoded.decode('utf-8')
 
     """ PRIVATE """
 


### PR DESCRIPTION
## Description

the base64 jumble obfuscator was broken for powershell commands

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

ran through commands and validated that they were able to be decoded and ran on windows boxes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
