### PR TITLE
fixing the psh command wrapper for b64 no padding obfuscator

### DIFF
--- a/app/obfuscators/base64_no_padding.py
+++ b/app/obfuscators/base64_no_padding.py
@@ -21,8 +21,7 @@ class Obfuscation(BaseObfuscator):
         return 'eval "$(echo %s=== | base64 --decode 2>/dev/null)"' % link.command
 
     def psh(self, link, **kwargs):
-        recoded = b64encode(link.command)
-        return '$string=%s;' +\
+        return '$string="%s";' % link.command +\
             'while($string.Length %4 -ne 0) {$string="$string="};' +\
-            '$ExecutionContext.InvokeCommand.ExpandString(' +\
-            '[System.Text.Encoding]::UTF8.GetString([convert]::FromBase64String($string)))' % recoded
+            'Invoke-Expression $ExecutionContext.InvokeCommand.ExpandString(' +\
+            '[System.Text.Encoding]::UTF8.GetString([convert]::FromBase64String($string)))'


### PR DESCRIPTION
## Description

Fixing the formatting and execution of the psh command to be sent to agents when using the base64 no padding obfuscator

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

ran through a handful of commands and made sure they formatted and executed correctly, also checked out and made sure the logic was sound

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
