### PR TITLE
Link uuids

### DIFF
--- a/app/donut.py
+++ b/app/donut.py
@@ -104,12 +104,12 @@ async def _get_parameters(data_svc, file_name, link_id=None):
     parameters = []
     operations = await data_svc.locate('operations', match=dict(state='running'))
     if link_id:
-        potential_links = [chain for operation in operations for chain in operation.chain
-                           if chain.id == link_id]
+        potential_links = [link for operation in operations for link in operation.chain
+                           if link.id == link_id]
     else:
-        potential_links = [chain for operation in operations for chain in operation.chain
-                           if not chain.finish and chain.ability.executor.startswith('donut')
-                           and file_name in chain.ability.payloads]
+        potential_links = [link for operation in operations for link in operation.chain
+                           if not link.finish and link.ability.executor.startswith('donut')
+                           and file_name in link.ability.payloads]
     if potential_links:
         link = sorted(potential_links, key=lambda l: l.decide)[0]
         operation = [operation for operation in operations if operation.has_link(link.id)][0]

--- a/app/donut.py
+++ b/app/donut.py
@@ -105,7 +105,7 @@ async def _get_parameters(data_svc, file_name, link_id=None):
     operations = await data_svc.locate('operations', match=dict(state='running'))
     if link_id:
         potential_links = [chain for operation in operations for chain in operation.chain
-                           if chain.id == int(link_id)]
+                           if chain.id == link_id]
     else:
         potential_links = [chain for operation in operations for chain in operation.chain
                            if not chain.finish and chain.ability.executor.startswith('donut')


### PR DESCRIPTION
## Description

Change Link IDs to use UUIDs instead of integers.

See: https://github.com/mitre/caldera/pull/2092

Also renamed `chain` to `link` because I was confused on the terminology when I wrote this.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Could not test. I originally had sandcat sending an `X-Link-Id` header when requesting a donut payload, but this code appears to have been removed...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works