### PR TITLE
VIRTS-1899, VIRTS-2011, & VIRTS-2010 - New printer queue discovery abilities

### DIFF
--- a/app/parsers/printer_queue.py
+++ b/app/parsers/printer_queue.py
@@ -7,6 +7,7 @@ class Parser(BaseParser):
     def parse(self, blob):
         relationships = []
         for match in self.line(blob):
+            # Ignore this row if it's a heading or doesn't contain queued document info
             first_char = match[0]
             if not first_char.isnumeric():
                 continue

--- a/app/parsers/printer_queue.py
+++ b/app/parsers/printer_queue.py
@@ -1,0 +1,27 @@
+from app.objects.secondclass.c_fact import Fact
+from app.objects.secondclass.c_relationship import Relationship
+from app.utility.base_parser import BaseParser
+import re
+
+class Parser(BaseParser):
+    def parse(self, blob):
+        relationships = []
+        for match in self.line(blob):
+            first_char = match[0]
+            if not first_char.isnumeric():
+                continue
+
+            split_match = re.split(" +", match)
+            file_name = " ".join(split_match[3:-2])
+            file_size = " ".join(split_match[-2:])
+
+            for mp in self.mappers:
+                source = self.set_value(mp.source, file_name, self.used_facts)
+                target = self.set_value(mp.target, file_size, self.used_facts)
+                relationships.append(
+                    Relationship(source=Fact(mp.source, source),
+                                 edge=mp.edge,
+                                 target=Fact(mp.target, target))
+                )
+
+        return relationships

--- a/data/abilities/discovery/6c91884e-11ec-422f-a6ed-e76774b0daac.yml
+++ b/data/abilities/discovery/6c91884e-11ec-422f-a6ed-e76774b0daac.yml
@@ -1,0 +1,24 @@
+- id: 6c91884e-11ec-422f-a6ed-e76774b0daac
+  name: View printer queue
+  description: View details of queued documents in printer queue
+  tactic: discovery
+  technique:
+    attack_id: T1120
+    name: Peripheral Device Discovery
+  platforms:
+    darwin:
+      sh:
+        command: lpq -a
+        parsers:
+          plugins.stockpile.app.parsers.printer_queue:
+          - source: host.print.file
+            edge: has_size
+            target: host.print.size
+    linux:
+      sh:
+        command: lpq -a
+        parsers:
+          plugins.stockpile.app.parsers.printer_queue:
+          - source: host.print.file
+            edge: has_size
+            target: host.print.size

--- a/data/abilities/discovery/a41c2324-8c63-4b15-b3c5-84f920d1f226.yml
+++ b/data/abilities/discovery/a41c2324-8c63-4b15-b3c5-84f920d1f226.yml
@@ -12,3 +12,9 @@
         parsers:
           plugins.stockpile.app.parsers.basic:
           - source: host.system.path
+    darwin:
+      sh:
+        command: 'find ~ -type f -name #{host.print.file} 2>/dev/null'
+        parsers:
+          plugins.stockpile.app.parsers.basic:
+          - source: host.system.path

--- a/data/abilities/discovery/a41c2324-8c63-4b15-b3c5-84f920d1f226.yml
+++ b/data/abilities/discovery/a41c2324-8c63-4b15-b3c5-84f920d1f226.yml
@@ -1,0 +1,14 @@
+- id: a41c2324-8c63-4b15-b3c5-84f920d1f226
+  name: Locate file from printer queue
+  description: Locate file that appears in the printer queue
+  tactic: discovery
+  technique:
+    attack_id: T1083
+    name: File and Directory Discovery
+  platforms:
+    linux:
+      sh:
+        command: 'find ~ -type f -name #{host.print.file} 2>/dev/null'
+        parsers:
+          plugins.stockpile.app.parsers.basic:
+          - source: host.system.path

--- a/data/adversaries/e4324b88-8836-4803-b6b7-09b3c6cd4e94.yml
+++ b/data/adversaries/e4324b88-8836-4803-b6b7-09b3c6cd4e94.yml
@@ -1,0 +1,7 @@
+name: Printer Queue
+description: Locate files that are queued for printing
+atomic_ordering:
+- 6c91884e-11ec-422f-a6ed-e76774b0daac #get printer queue
+- a41c2324-8c63-4b15-b3c5-84f920d1f226 #locate files that appear in the printer queue
+id: e4324b88-8836-4803-b6b7-09b3c6cd4e94
+objective: 495a9828-cab1-44dd-a0ca-66e58177d8cc


### PR DESCRIPTION
## Description

Added a new ability to get info about files queued for printing on Mac & Linux. Created a parser to parse the output from that ability. Created a second ability to locate the files that are queued for printing based on the parsed output from the first ability.
Added a new adversary profile which includes these 2 new abilities.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Ran the new abilities & new adversary profile & confirmed that the correct data was retrieved & returned to CALDERA server.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

