### PR TITLE
Adding no backwards movement requirement to prevent lateral movement loop

### DIFF
--- a/data/abilities/execution/95727b87-175c-4a69-8c7a-a5d82746a753.yml
+++ b/data/abilities/execution/95727b87-175c-4a69-8c7a-a5d82746a753.yml
@@ -19,3 +19,6 @@
           Start-Sleep -s 15;
           Get-Process -ComputerName #{remote.host.fqdn} s4ndc4t;
   singleton: True
+  requirements:
+    - plugins.stockpile.app.requirements.no_backwards_movement:
+        - source: remote.host.fqdn


### PR DESCRIPTION
## Description
In case the ability returns failure status but still spawns an agent on the remote host, the "no backwards movement" requirement is being added to prevent infinite lateral movement loops. Normally, the ability's "singleton" status will prevent a repeat of a successful command, but this will handle edge cases where the ability fails and thus "singleton" doesn't kick in (e.g. the service spawns the agent on the remote host, but get-process can't connect to the remote host - see https://github.com/mitre/caldera/issues/2162 for an example).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the ability and verified that the ability does not run on hosts that already have an agent that is part of the operation (also tested after removing the singleton clause).

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
