### PR TITLE
updates to planners for use with celery

### DIFF
--- a/app/atomic.py
+++ b/app/atomic.py
@@ -14,10 +14,9 @@ class LogicalPlanner:
     async def atomic(self):
         links_to_use = []
 
-        # Get the first available link for each agent (make sure we maintain the order).
-        for agent in self.operation.agents:
-            possible_agent_links = await self._get_links(agent=agent)
-            next_link = await self._get_next_atomic_link(possible_agent_links)
+        all_agents_links = await self._get_links()
+        for agent, possible_links in all_agents_links.items():
+            next_link = await self._get_next_atomic_link(possible_links)
             if next_link:
                 links_to_use.append(await self.operation.apply(next_link))
 
@@ -28,8 +27,8 @@ class LogicalPlanner:
             # No more links to run.
             self.next_bucket = None
 
-    async def _get_links(self, agent=None):
-        return await self.planning_svc.get_links(operation=self.operation, agent=agent)
+    async def _get_links(self):
+        return await self.planning_svc.get_links(operation=self.operation)
 
     # Given list of links, returns the link that appears first in the adversary's atomic ordering.
     async def _get_next_atomic_link(self, links):

--- a/app/batch.py
+++ b/app/batch.py
@@ -12,12 +12,13 @@ class LogicalPlanner:
         await self.planning_svc.execute_planner(self)
 
     async def batch(self):
-        links = await self._get_links()
+        agents_links = await self._get_links()
+        links = [link for links in agents_links.values() for link in links]
         while links:
             link_ids = [await self.operation.apply(link) for link in links]
             await self.operation.wait_for_links_completion(link_ids)
             # new links may be available now (e.g. requirements met)
-            links = await self._get_links()
+            links = [link for links in (await self._get_links()).values() for link in links]
         self.next_bucket = None
 
     async def _get_links(self):


### PR DESCRIPTION
## Description

Integration of celery tasks requires some minor updates to types being iterated over in the planners. This change makes updates to atomic and batch (the call to get_links for bucket is handled within the planning service).

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran Thief operation using all planners.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
