### PR TITLE
Advanced Domain Admin Enumeration

### DIFF
--- a/data/abilities/discovery/2afae782-6d0a-4fbd-a6b6-d1ce90090eac.yml
+++ b/data/abilities/discovery/2afae782-6d0a-4fbd-a6b6-d1ce90090eac.yml
@@ -10,12 +10,7 @@
       psh:
         command: |
           Import-Module .\powerview.ps1;
-          $userName = "#{domain.user.name}";
-          $userPassword = "#{domain.user.password}";
-
-          $secStringPassword = ConvertTo-SecureString $userPassword -AsPlainText -Force;
-          $credObject = New-Object System.Management.Automation.PSCredential ($userName, $secStringPassword);
-          Get-NetLocalGroupMember -ComputerName #{remote.host.fqdn} -Credential $credObject
+          Get-NetLocalGroupMember -ComputerName #{remote.host.fqdn}
         parsers:
           plugins.stockpile.app.parsers.netlocalgroup:
           - source: remote.host.fqdn
@@ -24,14 +19,3 @@
         payloads:
         - powerview.ps1
   singleton: True
-  requirements:
-    - plugins.stockpile.app.requirements.not_exists:
-        - source: remote.host.fqdn
-          edge: has_admin
-    - plugins.stockpile.app.requirements.basic:
-        - source: domain.user.name
-          edge: has_password
-          target: domain.user.password
-    - plugins.stockpile.app.requirements.reachable:
-        - source: remote.host.fqdn
-          edge: isAccessibleFrom

--- a/data/abilities/discovery/6d90e6fa-9324-4eb5-93be-9f737245bd7z.yml
+++ b/data/abilities/discovery/6d90e6fa-9324-4eb5-93be-9f737245bd7z.yml
@@ -1,0 +1,40 @@
+- id: 6d90e6fa-9324-4eb5-93be-9f737245bd7z
+  name: Account-type Admin Enumerator
+  description: Use PowerView to query the Active Directory server to determine remote admins
+  tactic: discovery
+  technique:
+    attack_id: T1069.002
+    name: "Permission Groups Discovery: Domain Groups"
+  platforms:
+    windows:
+      psh:
+        command: |
+          Import-Module .\powerview.ps1;
+          $backup = "#{backup.admin.ability}";
+          $userName = "#{domain.user.name}";
+          $userPassword = "#{domain.user.password}";
+          $secStringPassword = ConvertTo-SecureString $userPassword -AsPlainText -Force;
+          $credObject = New-Object System.Management.Automation.PSCredential ($userName, $secStringPassword);
+          Get-NetLocalGroupMember -ComputerName #{remote.host.fqdn} -Credential $credObject
+        parsers:
+          plugins.stockpile.app.parsers.netlocalgroup:
+          - source: remote.host.fqdn
+            edge: has_admin
+            target: domain.user.name
+        payloads:
+        - powerview.ps1
+  singleton: True
+  requirements:
+    - plugins.stockpile.app.requirements.not_exists:
+      - source: remote.host.fqdn
+        edge: has_admin
+    - plugins.stockpile.app.requirements.basic:
+      - source: backup.admin.ability
+        edge: first_failed
+    - plugins.stockpile.app.requirements.basic:
+      - source: domain.user.name
+        edge: has_password
+        target: domain.user.password
+    - plugins.stockpile.app.requirements.reachable:
+      - source: remote.host.fqdn
+        edge: isAccessibleFrom

--- a/data/adversaries/50855e29-3b4e-4562-aa55-b3d7f93c26b8.yml
+++ b/data/adversaries/50855e29-3b4e-4562-aa55-b3d7f93c26b8.yml
@@ -8,6 +8,7 @@ atomic_ordering:
   - 7049e3ec-b822-4fdf-a4ac-18190f9b66d1 # Invoke-Mimikatz
   - 14a21534-350f-4d83-9dd7-3c56b93a0c17 # nbtstat
   - 2afae782-6d0a-4fbd-a6b6-d1ce90090eac # get-netlocalgroup/admins
+  - 6d90e6fa-9324-4eb5-93be-9f737245bd7z # get-netlocalgroup/admins using Credential-Object (backup)
   - 921055f4-5970-4707-909e-62f594234d91 # ping to check firewall
   - aa6ec4dd-db09-4925-b9b9-43adeb154686 # Net Use
   - 65048ec1-f7ca-49d3-9410-10813e472b30 # SMB Copy


### PR DESCRIPTION
## Description

Modified the Domain Admin Enumeration ability in the 'Alice 2.0' adversary profile to run a previous version of the ability.
A backup ability is created and will run when the first ability does not collect the necessary information needed to form the proper relationships.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

New abilities and modified parser have been tested to ensure proper functionality.


## Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have made corresponding changes to the documentation
- [ X ] I have added tests that prove my fix is effective or that my feature works
