### PR TITLE
VIRTS 3278 updated paw_provenance to check for paw in collected_by list

### DIFF
--- a/app/requirements/paw_provenance.py
+++ b/app/requirements/paw_provenance.py
@@ -11,7 +11,6 @@ class Requirement(BaseRequirement):
         :return: True if it complies, False if it doesn't
         """
         for uf in link.used:
-            if self.enforcements['source'] == uf.trait:
-                if link.paw == uf.collected_by:
-                    return True
+            if self.enforcements['source'] == uf.trait and link.paw in uf.collected_by:
+                return True
         return False


### PR DESCRIPTION
## Description

The proposed change in this PR updates the paw_provenance requirement to check for an agent's paw in a fact's `collected_by` list instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the thief profile in an operation against a range of 6 hosts in AWS. All agents were running out of C:\Windows\System32 and, therefore, created the same `host.dir.staged`/`C:\Windows\System32\staged` fact. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
