### PR TITLE
Allow planners to be seen by blue users

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -5,7 +5,7 @@ from plugins.stockpile.app.stockpile_svc import StockpileService
 name = 'Stockpile'
 description = 'A stockpile of abilities, adversaries, payloads and planners'
 address = '/plugin/stockpile/gui'
-access = BaseWorld.Access.RED
+access = BaseWorld.Access.APP
 
 
 async def enable(services):


### PR DESCRIPTION
## Description

Access to stockpile was set to RED, which prevented BLUE users from seeing the planners included in the plugin. This caused the planner dropdown to be empty while creating a blue user operation, which is a part of the training plugin. This PR remedies the issue by allowing any user group to access stockpile.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Planner drop down is now populated while creating an operation as a blue user.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
