### PR TITLE
Fixed typo and old version of ability

### DIFF
--- a/data/abilities/collection/10fad81e-3f68-47be-83b6-fbee7711c6a9.yml
+++ b/data/abilities/collection/10fad81e-3f68-47be-83b6-fbee7711c6a9.yml
@@ -25,7 +25,11 @@
         payloads:
         - file_search.ps1
         cleanup: |
-          if (Test-Path -Path '.\file_search.ps1) {Remove-Item -Force -Path 'file_search.ps1'}
+          if ('#{windows.staging.location}' -match "recycle[``|\s]+bin") {
+                 $sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value;
+                 $StageDir = "C:\`$Recycle.Bin\$sid\s";
+          } else { $StageDir = '#{windows.staging.location}\s'; };
+          if (Test-Path -Path $StageDir) {Remove-Item -Force -Recurse $StageDir};
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.dir.staged
@@ -40,7 +44,7 @@
         payloads:
           - file_search.sh
         cleanup: |
-          if [-f ./file_search.sh ]; then rm -f ./file_search.sh; fi
+          if [ -d '#{linux.staging.location}' ]; then rm -rf '#{linux.staging.location}/.s'; fi;
         parsers:
           plugins.stockpile.app.parsers.basic:
             - source: host.dir.staged

--- a/data/adversaries/packs/eddc8f03-f930-41e7-95ba-33fb87bfed74.yml
+++ b/data/adversaries/packs/eddc8f03-f930-41e7-95ba-33fb87bfed74.yml
@@ -4,6 +4,6 @@ id: eddc8f03-f930-41e7-95ba-33fb87bfed74
 name: Advanced Thief
 description: An adversary to steal sensitive files
 atomic_ordering:
-    - 10fad81e-3f68-47be-83b6-fbee7711c6a0 # Advanced File Search and Stage
+    - 10fad81e-3f68-47be-83b6-fbee7711c6a9 # Advanced File Search and Stage
     - 300157e5-f4ad-4569-b533-9d1fa0e74d74 #compress staged dir
     - ea713bc4-63f0-491c-9a6f-0b01d560b87e #exfil compressed dir


### PR DESCRIPTION
The advanced thief profile had a small typo in the first ability UUID
which has been corrected. Additionally, an old version of the Advanced
Search and Stage ability was erroneously added. Updated to the final and tested
version that was originally intended for release.

## Description

Typo fix in adversary ability UUID. Another ability had a different version erroneously copied into Stockpile which has now been updated to the correct version. Other abilities part of the same commit and release were checked and should be the appropriate files.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Re-tested in an operation and received expected results with no errors.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
