### PR TITLE
Add look ahead planner

### DIFF
--- a/app/look_ahead.py
+++ b/app/look_ahead.py
@@ -1,0 +1,186 @@
+class LogicalPlanner:
+    """
+    The look ahead planner decides what abilities to use based on anticipated
+    future rewards. It takes as input a table of ability rewards, a depth
+    parameter, and a discount factor. The depth parameter effectively controls
+    the "look-ahead" for the planner as it's scoring each action, and the
+    discount factor controls how the planner weighs future rewards. (The
+    planner also only executes one action (i.e. link) at a time, even if
+    numerous agents).
+
+    Before describing the algorithm, some notation:
+
+    - Let g be the discount factor. This is defined globally. Default this to 0.9.
+    - Let d be the look-ahead depth. This is defined globally. Default this to 3.
+    - Let the set of abilities be A.
+    - Define a function E : A x P(A) to be a function that maps each ability a in
+      A to the set of abilities that follow a.
+    - We say that ability B follows ability A if there is a parser for A that
+      produces a fact that's input for B. Tying into language from above, we might
+      have an example where: E(a) = {b}.
+    - Let R : A x N be our reward table, mapping each ability to its immediate reward.
+
+    Pseudo-code of future reward calculation:
+
+    future_reward(current_ability, current_depth):
+        if current_depth > d:
+            return 0
+        future_rewards = []
+        for action in E(current_ability):
+            future_rewards.append(future_reward(action, current_depth + 1))
+        return R(current_ability) * g^(current_depth) + max(future_rewards)
+
+    """
+
+    DEPTH = 3
+    DISCOUNT = 0.9
+    DEFAULT_REWARD = 1
+
+    def __init__(
+        self,
+        operation,
+        planning_svc,
+        ability_rewards=None,
+        depth=DEPTH,
+        discount=DISCOUNT,
+        default_reward=DEFAULT_REWARD,
+        stopping_conditions=(),
+    ):
+        """
+        :param operation:
+        :param planning_svc:
+        :param ability_rewards:
+        :param depth:
+        :param discount:
+        :param default_reward:
+        :param stopping_conditions:
+        """
+        self.operation = operation
+        self.planning_svc = planning_svc
+        self.data_svc = planning_svc.get_service("data_svc")
+        self.ability_rewards = ability_rewards or {}
+        self.depth = depth
+        self.discount = discount
+        self.default_reward = default_reward
+        self.stopping_conditions = stopping_conditions
+        self.stopping_condition_met = False
+        self.state_machine = ["look_ahead"]
+        self.next_bucket = "look_ahead"  # repeat this bucket until we run out of links
+
+    async def execute(self):
+        await self.planning_svc.execute_planner(self)
+
+    async def look_ahead(self):
+        # get highest scoring link over all agents
+        agent_link_rewards = []
+        for agent in self.operation.agents:
+            # Step 1: We need to grab the full set of abilities
+            # that will be available to the agent to use
+            ao = self.operation.adversary.atomic_ordering
+            abilities = await self.data_svc.locate(
+                "abilities", match=dict(ability_id=tuple(ao))
+            )
+            abilities = await agent.capabilities(abilities)
+
+            # Step 2: Now get set of candidate links we will actually
+            # select a link from to execute
+            cand_links = await self.planning_svc.get_links(
+                self.operation, agent=agent, trim=True
+            )
+
+            # Step 3: Calculate rewards for each ability/executor (and
+            # all their future possible ability/action permutations)
+            ability_rewards = []
+            for ability in abilities:
+                ability_rewards.append(
+                    (
+                        ability.ability_id,
+                        await self._future_reward(
+                            agent, ability, abilities, 0
+                        ),
+                    )
+                )
+
+            # Step 4: Select link whose ability/executor has the
+            # highest reward, given the link/ability is executable (e.g.
+            # doesn't have missing facts)
+            next_link_and_reward = None
+            ability_rewards = sorted(ability_rewards, key=lambda r: r[1], reverse=True)
+            for ability_reward in ability_rewards:
+                ability_links = [
+                    link
+                    for link in cand_links
+                    if link.ability.ability_id == ability_reward[0]
+                ]
+                if ability_links:
+                    next_link_and_reward = (ability_links[0], ability_reward[1])
+                    break
+
+            if next_link_and_reward:
+                agent_link_rewards.append(next_link_and_reward)
+
+        # Now we have the highest scored link for each agent,
+        # select the link with the highest score from all the
+        # agents and push to agent
+        if agent_link_rewards:
+            agent_link_rewards = sorted(
+                agent_link_rewards, key=lambda r: r[1], reverse=True
+            )
+            link_id = await self.operation.apply(agent_link_rewards[0][0])
+            await self.operation.wait_for_links_completion([link_id])
+        else:
+            # No more links to run
+            self.next_bucket = None
+
+    async def _future_reward(self, agent, current_ability, abilities, current_depth):
+        """Calculate the reward for current ability
+        :param agent:
+        :param current_ability:
+        :param abilities:
+        :param current_depth:
+        :return: ability reward value
+        """
+        if current_depth > self.depth:
+            return 0
+        abilities = set(abilities) - set([current_ability])
+        future_rewards = [0]
+        abilities_that_follow = await self._abilities_that_follow(
+            agent, current_ability, abilities
+        )
+        for ability in abilities_that_follow:
+            future_rewards.append(
+                await self._future_reward(
+                    agent, ability, abilities, current_depth + 1
+                )
+            )
+        reward = round(
+            self.ability_rewards.get(current_ability.ability_id, self.default_reward)
+            * (self.discount**current_depth)
+            + max(future_rewards),
+            3,
+        )
+        return reward
+
+    async def _abilities_that_follow(self, agent, current_ability, abilities):
+        """Return list of abilities that could follow current ability
+        (based on whether the ability's command uses facts that are created/set
+        by the current ability)
+        :param agent:
+        :param current_ability:
+        :param abilities:
+        :return: list of abilities
+        """
+        current_executor = await agent.get_preferred_executor(current_ability)
+        facts = [
+            fact
+            for parser in current_executor.parsers
+            for cfg in parser.parserconfigs
+            for fact in [cfg.source, cfg.target]
+            if fact is not None and fact != ""
+        ]
+        next_abilities = []
+        for ability in abilities:
+            executor = await agent.get_preferred_executor(ability)
+            if executor.command and any(fact in executor.command for fact in facts):
+                next_abilities.append(ability)
+        return next_abilities

--- a/app/look_ahead.py
+++ b/app/look_ahead.py
@@ -57,15 +57,15 @@ class LogicalPlanner:
         """
         self.operation = operation
         self.planning_svc = planning_svc
-        self.data_svc = planning_svc.get_service("data_svc")
+        self.data_svc = planning_svc.get_service('data_svc')
         self.ability_rewards = ability_rewards or {}
         self.depth = depth
         self.discount = discount
         self.default_reward = default_reward
         self.stopping_conditions = stopping_conditions
         self.stopping_condition_met = False
-        self.state_machine = ["look_ahead"]
-        self.next_bucket = "look_ahead"  # repeat this bucket until we run out of links
+        self.state_machine = ['look_ahead']
+        self.next_bucket = 'look_ahead'  # repeat this bucket until we run out of links
 
     async def execute(self):
         await self.planning_svc.execute_planner(self)
@@ -78,7 +78,7 @@ class LogicalPlanner:
             # that will be available to the agent to use
             ao = self.operation.adversary.atomic_ordering
             abilities = await self.data_svc.locate(
-                "abilities", match=dict(ability_id=tuple(ao))
+                'abilities', match=dict(ability_id=tuple(ao))
             )
             abilities = await agent.capabilities(abilities)
 
@@ -95,9 +95,7 @@ class LogicalPlanner:
                 ability_rewards.append(
                     (
                         ability.ability_id,
-                        await self._future_reward(
-                            agent, ability, abilities, 0
-                        ),
+                        await self._future_reward(agent, ability, abilities, 0),
                     )
                 )
 
@@ -149,9 +147,7 @@ class LogicalPlanner:
         )
         for ability in abilities_that_follow:
             future_rewards.append(
-                await self._future_reward(
-                    agent, ability, abilities, current_depth + 1
-                )
+                await self._future_reward(agent, ability, abilities, current_depth + 1)
             )
         reward = round(
             self.ability_rewards.get(current_ability.ability_id, self.default_reward)
@@ -176,7 +172,7 @@ class LogicalPlanner:
             for parser in current_executor.parsers
             for cfg in parser.parserconfigs
             for fact in [cfg.source, cfg.target]
-            if fact is not None and fact != ""
+            if fact is not None and fact != ''
         ]
         next_abilities = []
         for ability in abilities:

--- a/data/planners/254c7035-de7d-4d76-a888-2c09ba594eca.yml
+++ b/data/planners/254c7035-de7d-4d76-a888-2c09ba594eca.yml
@@ -1,0 +1,14 @@
+---
+
+id: 254c7035-de7d-4d76-a888-2c09ba594eca.yml
+name: look ahead
+description: |
+  The look ahead planner decides what abilities to use based on anticipated
+  future rewards.  It takes as input a table of ability rewards, a depth
+  parameter, and a discount factor.  The depth parameter effectively controls
+  the "look-ahead" for the planner as it's scoring each action, and the
+  discount factor controls how the planner weighs future rewards.
+module: plugins.research.app.look_ahead
+params:
+  ability_rewards:
+    4e97e699-93d7-4040-b5a3-2e906a58199e: 5 # stage files

--- a/data/planners/254c7035-de7d-4d76-a888-2c09ba594eca.yml
+++ b/data/planners/254c7035-de7d-4d76-a888-2c09ba594eca.yml
@@ -8,7 +8,7 @@ description: |
   parameter, and a discount factor.  The depth parameter effectively controls
   the "look-ahead" for the planner as it's scoring each action, and the
   discount factor controls how the planner weighs future rewards.
-module: plugins.research.app.look_ahead
+module: plugins.stockpile.app.look_ahead
 params:
   ability_rewards:
     4e97e699-93d7-4040-b5a3-2e906a58199e: 5 # stage files


### PR DESCRIPTION
## Description

This change adds a look ahead planner. The look ahead planner decides what abilities to use based on anticipated future rewards.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Ran look ahead planner with Thief adversary and confirmed future reward calculations are correct
- Ran look ahead planner with all adversary abilities (Everything Bagel adversary) until completion, confirmed planner selects abilities as expected

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation