### PR TITLE
filepath resolution fix for darwin and linux

### DIFF
--- a/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
+++ b/data/abilities/collection/4e97e699-93d7-4040-b5a3-2e906a58199e.yml
@@ -11,11 +11,11 @@
     darwin:
       sh:
         command: |
-          cp "#{host.file.path[filters(technique=T1005,max=3)]}" #{host.dir.staged[filters(max=1)]}
+          cp #{host.file.path[filters(technique=T1005,max=3)]} #{host.dir.staged[filters(max=1)]}
     linux:
       sh:
         command: |
-          cp "#{host.file.path[filters(technique=T1005,max=3)]}" #{host.dir.staged[filters(max=1)]}
+          cp #{host.file.path[filters(technique=T1005,max=3)]} #{host.dir.staged[filters(max=1)]}
     windows:
       psh:
         command: |


### PR DESCRIPTION
## Description

The `stage sensitive files` ability uses the `host.file.path` fact to define the source file in its copy command.  For `darwin` and `linux` hosts, the command surrounds the file path in quotes in an attempt to handle spaces and escape characters.  The default `parser` for the `find files` ability (which generates `host.file.path` facts), already escapes these characters (e.g. ` `  becomes `\ `).

This is duplicitous, and results in unexpected behaviours for `darwin` or `linux` targets with non-trivial file paths.

As a concrete example, the `find files` ability may capture a new `host.file.path` fact from `stdout`, parsing `/Users/foo/My Directory/file.yml` as `/Users/foo/My\ Directory/file.yml`.  If this file path (the value of this `host.file.path` fact) is used in the current ability, the executed command becomes:
```bash
cp "/Users/foo/My\ Directory/file.yml" /Users/staged
```
when the desired command is
```bash
cp /Users/foo/My\ Directory/file.yml /Users/staged
```

As the `host.file.path` fact generated by `find files` is already escaped, the additional command-level quotes are unnecessary.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have tested this change locally, and can now successfully copy files with spaces in their file path using the `Thief` adversary. 


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
