### PR TITLE
fix caesar cipher issues, briefly tested locally on ubuntu and window…

### DIFF
--- a/app/obfuscators/caesar_cipher.py
+++ b/app/obfuscators/caesar_cipher.py
@@ -18,18 +18,24 @@ class Obfuscation(BaseObfuscator):
     def psh(self, link):
         decrypted = self.decode_bytes(link.command)
         encrypted, shift = self._apply_cipher(decrypted)
-        return '$encrypted = "' + encrypted + '"; $cmd = "''"; $encrypted = $encrypted.toCharArray(); ' \
-               'foreach ($letter in $encrypted) {$letter = [char](([int][char]$letter) - ' + str(shift) + '); ' \
-               '$cmd += $letter;} write-output $cmd;'
+        return "$encrypted = '" + encrypted.replace("'","''") + "'; $cmd = ''; $encrypted = $encrypted.toCharArray(); " \
+               'foreach ($letter in $encrypted) {Switch ([Byte]$letter) {' \
+               '{$_ -ge 65 -and $_ -le 90} {$cmd += [char](([int][char]$letter - ' + str(65 - shift) + ') % 26 + 65)}' \
+               '{$_ -ge 97 -and $_ -le 122} {$cmd += [char](([int][char]$letter - ' + str(97 - shift) + ') % 26 + 97)}' \
+               'Default {$cmd += $letter}}} powershell $cmd;'
 
     def sh(self, link):
         decrypted = self.decode_bytes(link.command)
         encrypted, shift = self._apply_cipher(decrypted)
-        return 'cmd=""; chr (){ [ "$1" -lt 256 ] || return 1; printf "\\\\$(printf \'%03o\' "$1")";};' \
-               'ord (){ LC_CTYPE=C printf \'%d\' "\'$1";return $LC_CTYPE; }; ' \
-               'st="' + encrypted + '"; for i in $(seq 1 ${#st}); do x=$(ord "${st:i-1:1}"); ' \
-               'if [[ "$x" =~ [^a-zA-Z] ]]; then x=$((x+ ' + str(-shift) + ')); fi; ' \
-               'cmd+="$(echo $(chr $x))";done;echo $cmd;'
+        return 'cmd=""; st="' + encrypted.replace('`','\\`').replace('\\','\\\\').replace('"','\\"') + \
+               '"; for i in $(seq 1 ${#st}); ' \
+               'do temp=$(printf %d\\\\n \\\'"$(expr substr "$st" $i 1)";); ' \
+               'if [ $temp -ge 65 ] && [ $temp -le 90 ]; ' \
+               'then temp=$((($temp - ' + str(65 - shift) + ') % 26 + 65)); fi; ' \
+               'if [ $temp -ge 97 ] && [ $temp -le 122 ]; ' \
+               'then temp=$((($temp - ' + str(97 - shift) + ') % 26 + 97)); fi; ' \
+               'cmd="${cmd}$(printf \\\\$(printf \'%03o\' $temp))";done;eval $cmd;'
+                
 
     """ PRIVATE """
 
@@ -42,4 +48,5 @@ class Obfuscation(BaseObfuscator):
         :return: a tuple containing the encoded command and the shift value
         """
         shift = randint(1, bounds)
-        return ''.join([chr(ord(c) + shift) if c.isalpha() else c for c in s]), shift
+        return ''.join([chr((ord(c) - 65 - shift) % 26 + 65) if (65 <= ord(c) <= 90) else 
+                       (chr((ord(c) - 97 - shift) % 26 + 97) if (97 <= ord(c) <= 122) else c) for c in s]), shift


### PR DESCRIPTION
…s 10

## Description

Previous caesar cipher obfuscator did not work for unix systems running sh (rather than bash) within sandcat (which seems to be the default), and for both sh and psh executors would only print out the command at the end (rather than actually execute it). It also had some issues with special characters that could cause the command to crash. I have made changes so that the caesar cipher only rotates letters within the original command, as well as escaping out special characters for each executor, so that these issues do not arise.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

I ran a couple operations in CALDERA using my changes to the caesar cipher obfuscator and they worked.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
