### PR TITLE
Added requirements for universal and existential quantifiers

### DIFF
--- a/app/requirements/existential.py
+++ b/app/requirements/existential.py
@@ -1,9 +1,14 @@
+from typing import List
+
+from app.objects.c_operation import Operation
+from app.objects.secondclass.c_link import Link
+
 from plugins.stockpile.app.requirements.base_requirement import BaseRequirement
 
 
 class Requirement(BaseRequirement):
 
-    async def enforce(self, link, operation):
+    async def enforce(self, link: Link, operation: Operation):
         """
         Given a link and the current operation, check that the operation's knowledge base contains
         at least one fact (and edge) that complies with the requirement.
@@ -15,10 +20,10 @@ class Requirement(BaseRequirement):
         filtered_facts = [fact for fact in facts if fact.trait == self.enforcements['source'] and
                                                     link.paw in fact.collected_by]
         if self.enforcements.get('edge', None):
-            filtered_facts = [fact for fact in filtered_facts if self._in_substring(self.enforcements['edge'], fact.relationships)]
-        if len(filtered_facts) > 0:
-            return True
-        return False
+            filtered_facts = [fact for fact in filtered_facts if self._in_relationship_substring(self.enforcements['edge'], fact.relationships)]
+        fulfilled = len(filtered_facts) > 0
 
-    def _in_substring(self, key, string_list):
-        return any(key in string for string in string_list)
+        return fulfilled
+
+    def _in_relationship_substring(self, key: str, relationships: List[str]):
+        return any(key in string for string in relationships)

--- a/app/requirements/existential.py
+++ b/app/requirements/existential.py
@@ -1,0 +1,24 @@
+from plugins.stockpile.app.requirements.base_requirement import BaseRequirement
+
+
+class Requirement(BaseRequirement):
+
+    async def enforce(self, link, operation):
+        """
+        Given a link and the current operation, check that the operation's knowledge base contains
+        at least one fact (and edge) that complies with the requirement.
+        :param link
+        :param operation
+        :return: True if it complies, False if it doesn't
+        """
+        facts = await operation.all_facts()
+        filtered_facts = [fact for fact in facts if fact.trait == self.enforcements['source'] and
+                                                    link.paw in fact.collected_by]
+        if self.enforcements.get('edge', None):
+            filtered_facts = [fact for fact in filtered_facts if self._in_substring(self.enforcements['edge'], fact.relationships)]
+        if len(filtered_facts) > 0:
+            return True
+        return False
+
+    def _in_substring(self, key, string_list):
+        return any(key in string for string in string_list)

--- a/app/requirements/universal.py
+++ b/app/requirements/universal.py
@@ -1,0 +1,23 @@
+from plugins.stockpile.app.requirements.base_requirement import BaseRequirement
+
+
+class Requirement(BaseRequirement):
+
+    async def enforce(self, link, operation):
+        """
+        Given a link and the current operation, check that all facts of a specified type in the
+        operation have a specified edge.
+        :param link
+        :param operation
+        :return: True if it complies, False if it doesn't
+        """
+        facts = await operation.all_facts()
+        matching_facts = [fact for fact in facts if fact.trait == self.enforcements['source'] and
+                                                    link.paw in fact.collected_by]
+        matching_edges = [fact for fact in matching_facts if self._in_substring(self.enforcements['edge'], fact.relationships)]
+        if len(matching_facts) == len(matching_edges):
+            return True
+        return False
+
+    def _in_substring(self, key, string_list):
+        return any(key in string for string in string_list)

--- a/app/requirements/universal.py
+++ b/app/requirements/universal.py
@@ -1,3 +1,8 @@
+from typing import List
+
+from app.objects.c_operation import Operation
+from app.objects.secondclass.c_link import Link
+
 from plugins.stockpile.app.requirements.base_requirement import BaseRequirement
 
 
@@ -14,10 +19,10 @@ class Requirement(BaseRequirement):
         facts = await operation.all_facts()
         matching_facts = [fact for fact in facts if fact.trait == self.enforcements['source'] and
                                                     link.paw in fact.collected_by]
-        matching_edges = [fact for fact in matching_facts if self._in_substring(self.enforcements['edge'], fact.relationships)]
-        if len(matching_facts) == len(matching_edges):
-            return True
-        return False
+        matching_edges = [fact for fact in matching_facts if self._in_relationship_substring(self.enforcements['edge'], fact.relationships)]
+        fulfilled = len(matching_facts) == len(matching_edges)
 
-    def _in_substring(self, key, string_list):
-        return any(key in string for string in string_list)
+        return fulfilled
+
+    def _in_relationship_substring(self, key: str, relationships: List[str]):
+        return any(key in string for string in relationships)


### PR DESCRIPTION
## Description

Implemented two new requirements that apply logical quantifiers to the knowledge base. These requirements expand Caldera's ability to plan by allowing for abilities to check facts against the entire knowledge base instead of only using facts used by the command.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

One of these requirements was used in tested closed-source abilities. The other is derived from the first.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
