### PR TITLE
basic requirement - treat empty string target like nonexistent

### DIFF
--- a/app/requirements/base_requirement.py
+++ b/app/requirements/base_requirement.py
@@ -12,7 +12,7 @@ class BaseRequirement:
         """
         if not self._check_edge(relationship.edge):
             return False
-        if 'target' in self.enforcements.keys():
+        if self.enforcements.get('target', None):
             for fact in used_facts:
                 if self._check_target(relationship.target, fact):
                     return True


### PR DESCRIPTION
## Description
address issue mentioned in https://github.com/mitre/caldera/issues/3177 where ability YAML files created by the GUI would have requirement 'target' field automatically generated and set to empty strings if no target is provided. Which would cause certain relationship checks to fail if only a source and edge are expected.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested with a basic ability that generated a fact with just an edge, and then another ability with a requirement that expected the fact+edge with an empty string target


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
