### PR TITLE
Add new static parser

### DIFF
--- a/app/parsers/static.py
+++ b/app/parsers/static.py
@@ -19,7 +19,7 @@ class Parser(BaseParser):
         parsers:
           - module: plugins.stockpile.app.parsers.static
             parserconfigs:
-              - source fact.value
+              - source: fact.value
                 custom_parser_vals:
                   source: 'fact value'
               - source: source.fact.value


### PR DESCRIPTION
## Description

This pull request adds the new Static Parser to the parsers of the stockpile plugin.
The static parser allows to create facts without actually parsing the information from the collected output.
Instead, the value of the generated fact can be configured directly.

The following usage example shows how the static parser can be configured and used:

```
command: 'whoami >> whoami_info.txt'
parsers:
  - module: plugins.stockpile.app.parsers.static
    parserconfigs:
      - source: target.whoami_info.file_name    # configure name of the fact here
        edge: ''
        target: ''
        custom_parser_vals:
          value: 'whoami_info.txt'             # configure value of the fact here
```

With the usage of the static parser, the file path to the collected information does not have to be extracted from the output. It can simply be configured in a static manner since the name is already defined in the command.
Myself and a student of mine have already used this parser on multiple occasions and I think it could be beneficial for every Caldera user.

If you have any questions, I am more than happy to answer them.

Best regards,
Louis

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Configure an ability to use the static parser like above
- Run an operation that executes this ability
- See the gathered fact in the ability's output


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
